### PR TITLE
Add support for properties to DataContractDatumConverter

### DIFF
--- a/rethinkdb-net-test/DatumConverters/DataContractDatumConverterTests.cs
+++ b/rethinkdb-net-test/DatumConverters/DataContractDatumConverterTests.cs
@@ -1,0 +1,87 @@
+using NUnit.Framework;
+using RethinkDb.Spec;
+
+namespace RethinkDb.Test.DatumConverters
+{
+    [TestFixture]
+    public class DataContractDatumConverterTests
+    {
+        private readonly IDatumConverter<TestObject2> testObject2Converter = DataContractDatumConverterFactory.Instance.Get<TestObject2>();
+        private readonly IDatumConverter<TestObject4> testObject4Converter = DataContractDatumConverterFactory.Instance.Get<TestObject4>();
+
+        [Test]
+        public void FieldDataContractConvertDatum()
+        {
+            var datum = new Datum() {
+                type = Datum.DatumType.R_OBJECT
+            };
+            datum.r_object.Add(new Datum.AssocPair() {
+                key = "name",
+                val = new Datum() {
+                    type = Datum.DatumType.R_STR,
+                    r_str = "Jackpot!",
+                }
+            });
+
+            var obj = testObject2Converter.ConvertDatum(datum);
+            Assert.That(obj, Is.Not.Null);
+            Assert.That(obj.Id, Is.EqualTo(0));
+            Assert.That(obj.Name, Is.EqualTo("Jackpot!"));
+        }
+
+        [Test]
+        public void FieldDataContractConvertObject()
+        {
+            var obj = new TestObject2() {
+                Name = "Jackpot!",
+            };
+            var datum = testObject2Converter.ConvertObject(obj);
+
+            Assert.That(datum.type, Is.EqualTo(Datum.DatumType.R_OBJECT));
+            Assert.That(datum.r_object.Count, Is.EqualTo(1));
+
+            var pair = datum.r_object[0];
+            Assert.That(pair.key, Is.EqualTo("name"));
+            Assert.That(pair.val.type, Is.EqualTo(Datum.DatumType.R_STR));
+            Assert.That(pair.val.r_str, Is.EqualTo("Jackpot!"));
+        }
+
+        [Test]
+        public void PropertyDataContractConvertDatum()
+        {
+            var datum = new Datum() {
+                type = Datum.DatumType.R_OBJECT
+            };
+            datum.r_object.Add(new Datum.AssocPair() {
+                key = "name",
+                val = new Datum() {
+                    type = Datum.DatumType.R_STR,
+                    r_str = "Jackpot!",
+                }
+            });
+
+            var obj = testObject4Converter.ConvertDatum(datum);
+            Assert.That(obj, Is.Not.Null);
+            Assert.That(obj.Id, Is.EqualTo(0));
+            Assert.That(obj.Name, Is.EqualTo("Jackpot!"));
+        }
+
+        [Test]
+        public void PropertyDataContractConvertObject()
+        {
+            var obj = new TestObject4() {
+                Name = "Jackpot!",
+            };
+            var datum = testObject4Converter.ConvertObject(obj);
+
+            Assert.That(datum.type, Is.EqualTo(Datum.DatumType.R_OBJECT));
+            Assert.That(datum.r_object.Count, Is.EqualTo(1));
+
+            var pair = datum.r_object[0];
+            Assert.That(pair.key, Is.EqualTo("name"));
+            Assert.That(pair.val.type, Is.EqualTo(Datum.DatumType.R_STR));
+            Assert.That(pair.val.r_str, Is.EqualTo("Jackpot!"));
+        }
+    }
+}
+

--- a/rethinkdb-net-test/TestObject4.cs
+++ b/rethinkdb-net-test/TestObject4.cs
@@ -1,0 +1,22 @@
+using System.Runtime.Serialization;
+
+namespace RethinkDb.Test
+{
+    [DataContract]
+    public class TestObject4
+    {
+        [DataMember(Name = "id", EmitDefaultValue = false)]
+        public double Id
+        {
+            get;
+            set;
+        }
+
+        [DataMember(Name = "name")]
+        public string Name
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/rethinkdb-net-test/rethinkdb-net-test.csproj
+++ b/rethinkdb-net-test/rethinkdb-net-test.csproj
@@ -92,6 +92,8 @@
     <Compile Include="DatumConverters\NullableGuidDatumConverterTests .cs" />
     <Compile Include="DatumConverters\DateTimeOffsetDatumConverterTests.cs" />
     <Compile Include="DatumConverters\NullableDateTimeOffsetDatumConverterTests.cs" />
+    <Compile Include="TestObject4.cs" />
+    <Compile Include="DatumConverters\DataContractDatumConverterTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />


### PR DESCRIPTION
DataContractDatmConverter only supports fields right now, but it should also support properties to match the expectations for [DataContract] classes.
