### PR TITLE
Mono 3.0.12 fixes #104.

### DIFF
--- a/rethinkdb-net-test/DatumConverters/DataContractDatumConverterTests.cs
+++ b/rethinkdb-net-test/DatumConverters/DataContractDatumConverterTests.cs
@@ -6,7 +6,6 @@ using NSubstitute;
 namespace RethinkDb.Test.DatumConverters
 {
     [TestFixture]
-    [Ignore("Crashes mono when run from command-line nunit-console.exe; see mfenniak/rethinkdb-net#104")]
     public class DataContractDatumConverterTests
     {
         private IDatumConverter<TestObject2> testObject2Converter;

--- a/rethinkdb-net-test/QueryTests/ReplaceQueryTests.cs
+++ b/rethinkdb-net-test/QueryTests/ReplaceQueryTests.cs
@@ -8,7 +8,6 @@ using RethinkDb.QueryTerm;
 namespace RethinkDb.Test.QueryTests
 {
     [TestFixture]
-    [Ignore("Crashes mono when run from command-line nunit-console.exe; see mfenniak/rethinkdb-net#104")]
     public class ReplaceQueryTests
     {
         private IDatumConverterFactory datumConverterFactory;

--- a/rethinkdb-net-test/QueryTests/UpdateQueryTests.cs
+++ b/rethinkdb-net-test/QueryTests/UpdateQueryTests.cs
@@ -8,7 +8,6 @@ using RethinkDb.QueryTerm;
 namespace RethinkDb.Test.QueryTests
 {
     [TestFixture]
-    [Ignore("Crashes mono when run from command-line nunit-console.exe; see mfenniak/rethinkdb-net#104")]
     public class UpdateQueryTests
     {
         private IDatumConverterFactory datumConverterFactory;


### PR DESCRIPTION
If you update to Mono 3.0.12, the tests will pass now without Mono crashing.
