### PR TITLE
Added support for the Parameter ExpressionType in SingleParameterLambda

### DIFF
--- a/rethinkdb-net-test/Integration/TestObject.cs
+++ b/rethinkdb-net-test/Integration/TestObject.cs
@@ -18,6 +18,9 @@ namespace RethinkDb.Test.Integration
         [DataMember(Name = "number")]
         public double SomeNumber;
 
+        [DataMember(Name = "tags")]
+        public string[] Tags;
+
         public override bool Equals(object obj)
         {
             var objTo = obj as TestObject;

--- a/rethinkdb-net/Expressions/SingleParameterLambda.cs
+++ b/rethinkdb-net/Expressions/SingleParameterLambda.cs
@@ -105,6 +105,23 @@ namespace RethinkDb.Expressions
         {
             switch (expr.NodeType)
             {
+                case ExpressionType.Parameter:
+                {
+                    return new Term()
+                    {
+                        type = Term.TermType.VAR,
+                        args = {
+                            new Term() {
+                                type = Term.TermType.DATUM,
+                                datum = new Datum() {
+                                    type = Datum.DatumType.R_NUM,
+                                    r_num = 2
+                                },
+                            }
+                        }
+                    };
+                }
+
                 case ExpressionType.MemberAccess:
                 {
                     var memberExpr = (MemberExpression)expr;


### PR DESCRIPTION
I'm assuming support for the Parameter type should be in place for this method. I was trying to run a ReQL query similar to:

```
r.db('db').table('table')
  .concatMap(function(b) { return b('tags') })
  .groupedMapReduce(
    function(t) { return t }, 
    function() { return 1 }, 
    function(x,y) { return x.add(y) })
```

but was encountering the following exception:
`System.InvalidOperationException : Failed to perform client-side evaluation of expression tree node; often this is caused by refering to a server-side variable in a node that is only supported w/ client-side evaluation` 

I added a test that mimics what I was trying to accomplish. Thanks!
