### PR TITLE
Unable to Connect to RethinkDB from ASP.NET Web Forms Application

### DIFF
--- a/rethinkdb-net/TaskUtilities.cs
+++ b/rethinkdb-net/TaskUtilities.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RethinkDb
+{
+    static class TaskUtilities
+    {
+        /// <summary>
+        /// Execute a void Task synchronously; this method is passed a delegate to create the task.
+        /// </summary>
+        /// <remarks>
+        /// Unlike calling the task's Wait() method, this method will discard the current synchronization context
+        /// before creating the task.  This will prevent any internal "await"'s from attempting to use the same
+        /// synchronization context, which can cause deadlocks (issue #130) depending upon the synchronization context
+        /// implementation.
+        /// </remarks>
+        public static void ExecuteSynchronously(Func<Task> taskDelegate)
+        {
+            var synchronizationContext = SynchronizationContext.Current;
+            try
+            {
+                SynchronizationContext.SetSynchronizationContext(null);
+                var task = taskDelegate();
+                task.Wait();
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(synchronizationContext);
+            }
+        }
+
+        /// <summary>
+        /// Execute a void Task synchronously; this method is passed a delegate to create the task.
+        /// </summary>
+        /// <remarks>
+        /// Unlike calling the task's Wait()/Result, this method will discard the current synchronization context
+        /// before creating the task.  This will prevent any internal "await"'s from attempting to use the same
+        /// synchronization context, which can cause deadlocks (issue #130) depending upon the synchronization context
+        /// implementation.
+        /// </remarks>
+        public static T ExecuteSynchronously<T>(Func<Task<T>> taskDelegate)
+        {
+            var synchronizationContext = SynchronizationContext.Current;
+            try
+            {
+                SynchronizationContext.SetSynchronizationContext(null);
+                var task = taskDelegate();
+                return task.Result;
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(synchronizationContext);
+            }
+        }
+    }
+}

--- a/rethinkdb-net/rethinkdb-net.csproj
+++ b/rethinkdb-net/rethinkdb-net.csproj
@@ -141,6 +141,7 @@
     <Compile Include="QueryTerm\DeleteAndReturnValueQuery.cs" />
     <Compile Include="QueryTerm\ReplaceAndReturnValueQuery.cs" />
     <Compile Include="QueryTerm\ReplaceQueryBase.cs" />
+    <Compile Include="TaskUtilities.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
I've created a sample ASP.NET Web Forms application in attempting to reproduce the issue reported as issue #129.  I was able to reproduce an unidentified hang in connecting to any RethinkDB database when hosted under a ASP.NET, under both the Visual Studio Development Server and IIS Express.

To produce this issue, first I created a new blank ASP.NET Web Forms project.  Then I populated the web.config as follows:

```
<?xml version="1.0"?>

<configuration>
  <configSections>
    <section name="rethinkdb" type="RethinkDb.Configuration.RethinkDbClientSection, RethinkDb" />
  </configSections>
  <system.web>
    <compilation debug="true" targetFramework="4.5" />
    <httpRuntime targetFramework="4.5" />
  </system.web>
  <rethinkdb>
    <clusters>
      <cluster name="testCluster">
        <endpoints>
          <endpoint address="10.210.27.106" port="28015" />
        </endpoints>
      </cluster>
    </clusters>
  </rethinkdb>
</configuration>
```

Then I created a Default.aspx page:

```
... snip boilerplate ...
<form id="form1" runat="server">
<div>
    <asp:BulletedList runat="server" ID="bulletList">
    </asp:BulletedList>
</div>
</form>
... snip boilerplate ...
```

With this code-behind:

```
public partial class Default : System.Web.UI.Page
{
    protected void Page_Load(object sender, EventArgs e)
    {
        var connection = ConfigConnectionFactory.Instance.Get("testCluster");
        connection.Connect();

        bulletList.DataSource = connection.Run(Query.DbList());
        bulletList.DataBind();
    }
}
```

When loading the above Default.aspx page under a debugger and stepping into the Connect method, the connect processing seems to "disappear" around this line in DoTryConnect (Connection.cs:156):

```
await taskFactory.FromAsync(
    (asyncCallback, asyncState) => socket.BeginConnect(endpoint.Address, endpoint.Port, asyncCallback, asyncState),
    ar => socket.EndConnect(ar),
    null
);
```

The DoTryConnect async method never continues to execute.
