### PR TITLE
Support real-time push of change notifications on most operations

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,6 +10,10 @@
 
 * Add support for Enumerable.Any() and Enumerable.Contains() methods to be mapped into a RethinkDB "contains" query term.  [Issue #196](https://github.com/mfenniak/rethinkdb-net/issues/196)
 
+* Add a new "StreamChanges" and "StreamChangesAsync" extension methods to IConnection, which do not use the connection's query timeout when executing server-side commands.  [Issue #193](https://github.com/mfenniak/rethinkdb-net/issues/193)
+
+* Allow the Changes query command to be run against any query that returns a sequence of objects, rather than just a table.  This is supported as-of RethinkDB 1.16.  [Issue #190](https://github.com/mfenniak/rethinkdb-net/issues/190)
+
 
 ## 0.9.1.0 (2014-10-31)
 

--- a/rethinkdb-net-test/Integration/RealtimePushTests.cs
+++ b/rethinkdb-net-test/Integration/RealtimePushTests.cs
@@ -1,13 +1,10 @@
 ﻿using System;
-using NUnit.Framework;
-using RethinkDb;
-using System.Net;
-using System.Linq;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Collections.Generic;
-using System.Linq.Expressions;
 using FluentAssertions;
+using NUnit.Framework;
+using RethinkDb;
 
 namespace RethinkDb.Test.Integration
 {
@@ -104,7 +101,7 @@ namespace RethinkDb.Test.Integration
             e2.Should().BeNull();
         }
 
-        // Changes on a single record not currently supported by rethinkdb-net, but should be.
+        // Changes on a single record not currently supported by rethinkdb-net, but should be; issue #197.
         //[Test]
         //public void ChangesOnPrimaryKey()
         //{
@@ -217,7 +214,7 @@ namespace RethinkDb.Test.Integration
         }
 
         /*
-         * Min / Max operations on indexes not currently supported, but should be.
+         * Min / Max operations on indexes not currently supported, but should be; issue #198
 
         [Test]
         [Timeout(1000)]

--- a/rethinkdb-net-test/Integration/RealtimePushTests.cs
+++ b/rethinkdb-net-test/Integration/RealtimePushTests.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using NUnit.Framework;
+using RethinkDb;
+using System.Net;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using FluentAssertions;
+
+namespace RethinkDb.Test.Integration
+{
+    [TestFixture]
+    public class RealtimePushTests : TestBase
+    {
+        private ITableQuery<TestObject> testTable;
+
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+            connection.Run(Query.DbCreate("test"));
+            connection.Run(Query.Db("test").TableCreate("table"));
+            testTable = Query.Db("test").Table<TestObject>("table");
+        }
+
+        [SetUp]
+        public virtual void SetUp()
+        {
+            connection.Run(testTable.Insert(new List<TestObject> {
+                new TestObject() { Id = "1", Name = "1", SomeNumber = 1, Tags = new[] { "odd" }, Children = new TestObject[] { new TestObject { Name = "C1" } }, ChildrenList = new List<TestObject> { new TestObject() { Name = "C1" } }, ChildrenIList = new List<TestObject> { new TestObject() { Name = "C1" } } },
+                new TestObject() { Id = "2", Name = "2", SomeNumber = 2, Tags = new[] { "even" }, Children = new TestObject[0], ChildrenList = new List<TestObject> { }, ChildrenIList = new List<TestObject> { } },
+                new TestObject() { Id = "3", Name = "3", SomeNumber = 3, Tags = new[] { "odd" }, Children = new TestObject[] { new TestObject { Name = "C3" } }, ChildrenList = new List<TestObject> { new TestObject() { Name = "C3" } }, ChildrenIList = new List<TestObject> { new TestObject() { Name = "C3" } } },
+                new TestObject() { Id = "4", Name = "4", SomeNumber = 4, Tags = new[] { "even" }, Children = new TestObject[0], ChildrenList = new List<TestObject> { }, ChildrenIList = new List<TestObject> { } },
+                new TestObject() { Id = "5", Name = "5", SomeNumber = 5, Tags = new[] { "odd" }, Children = new TestObject[] { new TestObject { Name = "C5" } }, ChildrenList = new List<TestObject> { new TestObject() { Name = "C5" } }, ChildrenIList = new List<TestObject> { new TestObject() { Name = "C5" } } },
+                new TestObject() { Id = "6", Name = "6", SomeNumber = 6, Tags = new[] { "even" }, Children = new TestObject[0], ChildrenList = new List<TestObject> { }, ChildrenIList = new List<TestObject> { } },
+                new TestObject() { Id = "7", Name = "7", SomeNumber = 7, Tags = new[] { "odd" }, Children = new TestObject[] { new TestObject { Name = "C7" } }, ChildrenList = new List<TestObject> { new TestObject() { Name = "C7" } }, ChildrenIList = new List<TestObject> { new TestObject() { Name = "C7" } } },
+            }));
+        }
+
+        [TearDown]
+        public virtual void TearDown()
+        {
+            connection.Run(testTable.Delete());
+        }
+
+        //[Test]
+        //public void ChangesOnPrimaryKey()
+        //{
+        //    foreach (var row in testTable.Get("Id").Changes())
+        //    {
+        //    }
+        //}
+
+        private void RealtimePushTestSingleResponse(
+            Func<IStreamingSequenceQuery<DmlResponseChange<TestObject>>> createStreamingQuery,
+            Action doModifications,
+            Action<DmlResponseChange<TestObject>> verifyStreamingResults)
+        {
+            Exception e1 = null;
+            Exception e2 = null;
+
+            ManualResetEvent sync1 = new ManualResetEvent(false);
+
+            var thread1 = new Thread(() =>
+            {
+                try
+                {
+                    var query = createStreamingQuery();
+                    var enumerator = connection.StreamChangesAsync(query);
+                    var task = enumerator.MoveNext();
+                    sync1.Set(); // inform other thread that we're ready for it to make changes
+                    task.Wait();
+                    task.Result.Should().BeTrue();
+
+                    verifyStreamingResults(enumerator.Current);
+                }
+                catch (Exception e)
+                {
+                    e1 = e;
+                }
+            });
+
+            var thread2 = new Thread(() =>
+            {
+                try
+                {
+                    sync1.WaitOne();
+                    doModifications();
+                }
+                catch (Exception e)
+                {
+                    e2 = e;
+                }
+            });
+
+            thread1.Start();
+            thread2.Start();
+
+            thread1.Join();
+            thread2.Join();
+
+            e1.Should().BeNull();
+            e2.Should().BeNull();
+        }
+
+        [Test]
+        [Timeout(1000)]
+        public void ChangesWithBetween()
+        {
+            RealtimePushTestSingleResponse(
+                () => testTable.Between("2", "4").Changes(),
+                () =>
+                {
+                    var result = connection.Run(testTable.Get("3").Update(o => new TestObject() { Name = "Updated!" }));
+                    result.Should().NotBeNull();
+                    result.Replaced.Should().Be(1.0);
+                },
+                response =>
+                {
+                    response.OldValue.Name.Should().Be("3");
+                    response.NewValue.Name.Should().Be("Updated!");
+                }
+            );
+        }
+    }
+}

--- a/rethinkdb-net-test/Integration/RealtimePushTests.cs
+++ b/rethinkdb-net-test/Integration/RealtimePushTests.cs
@@ -51,7 +51,7 @@ namespace RethinkDb.Test.Integration
 
             ManualResetEvent sync1 = new ManualResetEvent(false);
 
-            var thread1 = new Thread(async () =>
+            var thread1 = new Thread(() =>
             {
                 try
                 {
@@ -62,14 +62,14 @@ namespace RethinkDb.Test.Integration
                         enumerator = connection.StreamChangesAsync(query);
                         var task = enumerator.MoveNext();
                         sync1.Set(); // inform other thread that we're ready for it to make changes
-                        var result = await task;
-                        result.Should().BeTrue();
+                        task.Wait();
+                        task.Result.Should().BeTrue();
 
                         verifyStreamingResults(enumerator.Current);
                     }
                     finally
                     {
-                        await enumerator.Dispose();
+                        enumerator.Dispose().Wait();
                     }
                 }
                 catch (Exception e)

--- a/rethinkdb-net-test/Integration/TableTests.cs
+++ b/rethinkdb-net-test/Integration/TableTests.cs
@@ -480,35 +480,5 @@ namespace RethinkDb.Test.Integration
             })).Single();
             Assert.That(result.DTO, Is.EqualTo(new DateTimeOffset(2014, 1, 2, 3, 4, 5, 9, TimeSpan.FromHours(-2.5))));
         }
-
-        [Test]
-        [Ignore("Disable until PR #199 which will have better tests")]
-        public void Changes()
-        {
-            DoChanges().Wait();
-        }
-
-        private async Task DoChanges()
-        {
-            var enumerator = connection.RunAsync(testTable.Changes());
-            try
-            {
-                var moveNext = enumerator.MoveNext();
-                using (var secondConnection = ConnectionFactory.Get())
-                {
-                    await secondConnection.RunAsync(testTable.Insert(new TestObject() { Name = "Jim Brown" }));
-                }
-
-                Assert.That(await moveNext, Is.True);
-                var change = enumerator.Current;
-                Assert.That(change.OldValue, Is.Null);
-                Assert.That(change.NewValue, Is.Not.Null);
-                Assert.That(change.NewValue.Name, Is.EqualTo("Jim Brown"));
-            }
-            finally
-            {
-                enumerator.Dispose().Wait();
-            }
-        }
     }
 }

--- a/rethinkdb-net-test/rethinkdb-net-test.csproj
+++ b/rethinkdb-net-test/rethinkdb-net-test.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Expressions\GuidExpressionTests.cs" />
     <Compile Include="DatumConverters\BinaryDatumConverterTests.cs" />
     <Compile Include="DatumConverters\DefaultDatumConverterTests.cs" />
+    <Compile Include="Integration\RealtimePushTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/rethinkdb-net/Interfaces/IStreamingSequenceQuery.cs
+++ b/rethinkdb-net/Interfaces/IStreamingSequenceQuery.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace RethinkDb
+{
+    [ImmutableObject(true)]
+    public interface IStreamingSequenceQuery<T> : ISequenceQuery<T>
+    {
+    }
+}

--- a/rethinkdb-net/Query.cs
+++ b/rethinkdb-net/Query.cs
@@ -131,7 +131,7 @@ namespace RethinkDb
             return new InsertQuery<T>(target, @objects, conflict);
         }
 
-        public static ISequenceQuery<DmlResponseChange<TRecord>> Changes<TRecord>(this ITableQuery<TRecord> target)
+        public static IStreamingSequenceQuery<DmlResponseChange<TRecord>> Changes<TRecord>(this ISequenceQuery<TRecord> target)
         {
             return new ChangesQuery<TRecord>(target);
         }

--- a/rethinkdb-net/QueryTerm/ChangesQuery.cs
+++ b/rethinkdb-net/QueryTerm/ChangesQuery.cs
@@ -4,13 +4,13 @@ using System.Linq.Expressions;
 
 namespace RethinkDb.QueryTerm
 {
-    public class ChangesQuery<TRecord> : ISequenceQuery<DmlResponseChange<TRecord>>
+    public class ChangesQuery<TRecord> : IStreamingSequenceQuery<DmlResponseChange<TRecord>>
     {
-        private readonly ITableQuery<TRecord> tableQuery;
+        private readonly ISequenceQuery<TRecord> sequenceQuery;
 
-        public ChangesQuery(ITableQuery<TRecord> tableQuery)
+        public ChangesQuery(ISequenceQuery<TRecord> sequenceQuery)
         {
-            this.tableQuery = tableQuery;
+            this.sequenceQuery = sequenceQuery;
         }
 
         public Term GenerateTerm(IQueryConverter queryConverter)
@@ -19,7 +19,7 @@ namespace RethinkDb.QueryTerm
             {
                 type = Term.TermType.CHANGES,
             };
-            term.args.Add(tableQuery.GenerateTerm(queryConverter));
+            term.args.Add(sequenceQuery.GenerateTerm(queryConverter));
             return term;
         }
     }

--- a/rethinkdb-net/SynchronousApiExtensions.cs
+++ b/rethinkdb-net/SynchronousApiExtensions.cs
@@ -34,6 +34,11 @@ namespace RethinkDb
             return new AsyncEnumerableSynchronizer<T>(() => connection.RunAsync<T>(queryObject, queryConverter), cancellationToken);
         }
 
+        public static IEnumerable<T> StreamChanges<T>(this IConnection connection, IStreamingSequenceQuery<T> queryObject, IQueryConverter queryConverter = null, CancellationToken? cancellationToken = null)
+        {
+            return new AsyncEnumerableSynchronizer<T>(() => connection.StreamChangesAsync<T>(queryObject, queryConverter), cancellationToken);
+        }
+
         #endregion
         #region AsyncEnumerable synchronous wrappers
 

--- a/rethinkdb-net/rethinkdb-net.csproj
+++ b/rethinkdb-net/rethinkdb-net.csproj
@@ -219,6 +219,7 @@
     <Compile Include="IndexStatus.cs" />
     <Compile Include="QueryTerm\IndexStatusQuery.cs" />
     <Compile Include="QueryTerm\IndexWaitQuery.cs" />
+    <Compile Include="Interfaces\IStreamingSequenceQuery.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
This PR fixes #193 and #180.

Requires some test fixes for RethinkDB 1.16 (PR #200) compatibility before this can be merged.