### PR TITLE
Fix hardcoded US date time format in unit tests

### DIFF
--- a/rethinkdb-net-newtonsoft-test/DatumConversion/DateTimeOffsetTests.cs
+++ b/rethinkdb-net-newtonsoft-test/DatumConversion/DateTimeOffsetTests.cs
@@ -15,7 +15,7 @@ namespace RethinkDb.Newtonsoft.Test.DatumConversion
             var obj = new ADateTimeOffset()
                 {
                     Id = "my_id",
-                    TheDateTimeOffset = DateTimeOffset.Parse("10/30/2013 4:12:02 PM -07:00")
+                    TheDateTimeOffset = DateTimeOffset.Parse("30 Oct 2013 4:12:02 PM -07:00")
                 };
 
             var truth = new Datum
@@ -101,7 +101,7 @@ namespace RethinkDb.Newtonsoft.Test.DatumConversion
             var obj = new DateTimeOffsetNullable()
                 {
                     Id = "my_id",
-                    TheDateTimeOffset = DateTimeOffset.Parse("10/30/2013 4:12:02 PM -07:00")
+                    TheDateTimeOffset = DateTimeOffset.Parse("30 Oct 2013 4:12:02 PM -07:00")
                 };
 
             var truth = new Datum

--- a/rethinkdb-net-newtonsoft-test/DatumConversion/DateTimeTests.cs
+++ b/rethinkdb-net-newtonsoft-test/DatumConversion/DateTimeTests.cs
@@ -50,7 +50,7 @@ namespace RethinkDb.Newtonsoft.Test.DatumConversion
             var obj = new ADateTime
                 {
                     Id = "my_id_value",
-                    TheDate = DateTime.Parse("10/30/2013 4:55 PM")
+                    TheDate = DateTime.Parse("30 Oct 2013 4:55 PM")
                 };
 
             var truth = new Datum
@@ -137,7 +137,7 @@ namespace RethinkDb.Newtonsoft.Test.DatumConversion
             var obj = new DateTimeNullable()
                 {
                     Id = "my_id",
-                    NullableDateTime = DateTime.Parse("10/30/2013 4:55 PM")
+                    NullableDateTime = DateTime.Parse("30 Oct 2013 4:55 PM")
                 };
 
             var truth = new Datum

--- a/rethinkdb-net-newtonsoft-test/DatumConversion/FatDateTimeTests.cs
+++ b/rethinkdb-net-newtonsoft-test/DatumConversion/FatDateTimeTests.cs
@@ -117,12 +117,12 @@ namespace RethinkDb.Newtonsoft.Test.DatumConversion
                 {
                     Id = Guid.Parse("{32753EDC-E5EF-46E0-ABCD-CE5413B30797}"),
                     Name = "Brian Chavez",
-                    TheDateTime = DateTime.Parse("10/26/2013 3:45 PM"),
+                    TheDateTime = DateTime.Parse("26 Oct 2013 3:45 PM"),
                     NullDateTime = null,
-                    NotNullDateTime = DateTime.Parse("10/26/2013 3:45 PM"),
-                    TheDateTimeOffset = DateTimeOffset.Parse("10/26/2013 8:27:02 PM -07:00"),
+                    NotNullDateTime = DateTime.Parse("26 Oct 2013 3:45 PM"),
+                    TheDateTimeOffset = DateTimeOffset.Parse("26 Oct 2013 8:27:02 PM -07:00"),
                     NullDateTimeOffset = null,
-                    NotNullDateTimeOffset = DateTimeOffset.Parse("10/26/2013 8:27:02 PM -07:00")
+                    NotNullDateTimeOffset = DateTimeOffset.Parse("26 Oct 2013 8:27:02 PM -07:00")
                 };
 
             return obj;


### PR DESCRIPTION
I'm an Australian and our general date format is dd/mm/yyyy like many other countries, so 10/30/2013 is an illegal date to parse. I've fixed the unit tests to remove this ambiguity.

If you'd prefer I can change them to using the `DateTime` and `DateTimeOffset` constructors.

```
RethinkDb.Newtonsoft.Test.DatumConversion.DateTimeOffsetTests.ser_deser_a_datetimeoffset : System.FormatException : String was not recognized as a valid DateTime.
at System.DateTimeOffset.Parse (System.String input, IFormatProvider formatProvider, DateTimeStyles styles) [0x00000] in <filename unknown>:0
at System.DateTimeOffset.Parse (System.String input, IFormatProvider formatProvider) [0x00000] in <filename unknown>:0
at System.DateTimeOffset.Parse (System.String input) [0x00000] in <filename unknown>:0
at RethinkDb.Newtonsoft.Test.DatumConversion.DateTimeOffsetTests.ser_deser_a_datetimeoffset () [0x00000] in <filename unknown>:0
at (wrapper managed-to-native) System.Reflection.MonoMethod:InternalInvoke (System.Reflection.MonoMethod,object,object[],System.Exception&)
at System.Reflection.MonoMethod.Invoke (System.Object obj, BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00000] in <filename unknown>:0
```