### PR TITLE
Extend wait time and disable HTTP admin port for integration unit tests

### DIFF
--- a/rethinkdb-net-test/Integration/IntegrationTestSetup.cs
+++ b/rethinkdb-net-test/Integration/IntegrationTestSetup.cs
@@ -37,7 +37,7 @@ namespace RethinkDb.Test.Integration
             var locations = path.Split(Path.PathSeparator).ToList();
 
             // Something is modifying PATH when running via xamarin studio, making it exclude several things
-            // including /usr/local/bin. EnvironmentVariableTarget.User returns null. 
+            // including /usr/local/bin. EnvironmentVariableTarget.User returns null.
             // So this uglyness has to stay for now?
             locations.Add("/usr/local/bin");
 
@@ -102,20 +102,20 @@ namespace RethinkDb.Test.Integration
             var processInfo = new ProcessStartInfo()
             {
                 FileName = GetRethinkPath(),
-                Arguments = "-d " + dbPath + " --cluster-port 55557 --driver-port " + rethinkEndpoint.Port,
+                Arguments = string.Format("-d {0} --cluster-port 55557 --driver-port {1} --no-http-admin", dbPath, rethinkEndpoint.Port),
                 UseShellExecute = false
             };
             rethinkProcess = Process.Start(processInfo);
 
             // wait for it to start up, but not forever
             int waited = 0;
-            while (!IsEndpointAvailable(rethinkEndpoint) && waited < 30)
+            while (!IsEndpointAvailable(rethinkEndpoint) && waited < 60)
             {
                 Thread.Sleep(250);
                 waited++;
             }
 
-            if (waited >= 30)
+            if (waited >= 60)
                 throw new Exception("Could not start rethinkdb.");
         }
     }


### PR DESCRIPTION
I've increased the amount of time the integration unit tests wait for RethinkDB to start because on my machine it regularly takes more than 7.5 seconds, I've bumped it up to 15 seconds.

I also disabled the HTTP web admin listener under the integration tests because it failed to start the first time I ran the tests because it is using the default port 8080 (and I've got another RethinkDB installed) and isn't needed for rethinkdb-net.