### PR TITLE
Supporting comparison to null in Filter expression

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -20,6 +20,10 @@
 
 * RethinkDB 1.16 changed the DML response to use the fields "dbs_created", "dbs_dropped", "tables_created", and "tables_dropped" in preference over the "created" and "dropped" fields.  To support this, RethinkDb.DmlREsponse now has four additional fields that map to these values.  The old fields, Created and Dropped, are still used to report on index operations.  [PR #200](https://github.com/mfenniak/rethinkdb-net/pull/200)
 
+### Bugfixes
+
+* Fix errors that occur when writing obvious filters like ```... == null`` and ```field.HasValue```.  [Issue #203](https://github.com/mfenniak/rethinkdb-net/issues/203) & [PR #204](https://github.com/mfenniak/rethinkdb-net/issues/204)
+
 
 ## 0.9.1.0 (2014-10-31)
 

--- a/rethinkdb-net-newtonsoft/Configuration/NewtonSerializer.cs
+++ b/rethinkdb-net-newtonsoft/Configuration/NewtonSerializer.cs
@@ -9,8 +9,9 @@ namespace RethinkDb.Newtonsoft.Configuration
             TupleDatumConverterFactory.Instance,
             AnonymousTypeDatumConverterFactory.Instance,
             BoundEnumDatumConverterFactory.Instance,
+            NullableDatumConverterFactory.Instance,
             NewtonsoftDatumConverterFactory.Instance
-            )
+        )
         {
         }
     }

--- a/rethinkdb-net-test/Integration/MultiObjectTests.cs
+++ b/rethinkdb-net-test/Integration/MultiObjectTests.cs
@@ -1077,6 +1077,7 @@ namespace RethinkDb.Test.Integration
         [Test]
         public void NullFilter()
         {
+            connection.Run(testTable.Delete());
             connection.Run(testTable.Insert(new TestObject() { Id = "1", Name = "Has a Name" }));
             connection.Run(testTable.Insert(new TestObject() { Id = "2", Name = null }));
 
@@ -1092,6 +1093,7 @@ namespace RethinkDb.Test.Integration
         [Test]
         public void NotNullFilter()
         {
+            connection.Run(testTable.Delete());
             connection.Run(testTable.Insert(new TestObject() { Id = "1", Name = "Has a Name" }));
             connection.Run(testTable.Insert(new TestObject() { Id = "2", Name = null }));
 

--- a/rethinkdb-net-test/Integration/MultiObjectTests.cs
+++ b/rethinkdb-net-test/Integration/MultiObjectTests.cs
@@ -1073,5 +1073,35 @@ namespace RethinkDb.Test.Integration
             }
             Assert.That(count, Is.EqualTo(1));
         }
+
+        [Test]
+        public void NullFilter()
+        {
+            connection.Run(testTable.Insert(new TestObject() { Id = "1", Name = "Has a Name" }));
+            connection.Run(testTable.Insert(new TestObject() { Id = "2", Name = null }));
+
+            int count = 0;
+            foreach (var row in connection.Run(testTable.Filter(o => o.Name == null)))
+            {
+                row.Id.Should().Be("2");
+                count += 1;
+            }
+            count.Should().Be(1);
+        }
+
+        [Test]
+        public void NotNullFilter()
+        {
+            connection.Run(testTable.Insert(new TestObject() { Id = "1", Name = "Has a Name" }));
+            connection.Run(testTable.Insert(new TestObject() { Id = "2", Name = null }));
+
+            int count = 0;
+            foreach (var row in connection.Run(testTable.Filter(o => o.Name != null)))
+            {
+                row.Id.Should().Be("1");
+                count += 1;
+            }
+            count.Should().Be(1);
+        }
     }
 }

--- a/rethinkdb-net-test/Integration/TableTests.cs
+++ b/rethinkdb-net-test/Integration/TableTests.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using FluentAssertions;
 
 namespace RethinkDb.Test.Integration
 {
@@ -479,6 +480,66 @@ namespace RethinkDb.Test.Integration
                 DTO = new DateTimeOffset(2014, 1, 2, 3, 4, 5, testObject.Value_Int, TimeSpan.FromHours(-2.5)),
             })).Single();
             Assert.That(result.DTO, Is.EqualTo(new DateTimeOffset(2014, 1, 2, 3, 4, 5, 9, TimeSpan.FromHours(-2.5))));
+        }
+
+        [Test]
+        public void NullableNullFilter()
+        {
+            connection.Run(testTable3.Insert(new TestObject3() { Id = 1, Value_Int_Nullable = 100}));
+            connection.Run(testTable3.Insert(new TestObject3() { Id = 2, Value_Int_Nullable = null }));
+
+            int count = 0;
+            foreach (var row in connection.Run(testTable3.Filter(o => o.Value_Int_Nullable == null)))
+            {
+                row.Id.Should().Be(2);
+                count += 1;
+            }
+            count.Should().Be(1);
+        }
+
+        [Test]
+        public void NullableNotNullFilter()
+        {
+            connection.Run(testTable3.Insert(new TestObject3() { Id = 1, Value_Int_Nullable = 100}));
+            connection.Run(testTable3.Insert(new TestObject3() { Id = 2, Value_Int_Nullable = null }));
+
+            int count = 0;
+            foreach (var row in connection.Run(testTable3.Filter(o => o.Value_Int_Nullable != null)))
+            {
+                row.Id.Should().Be(1);
+                count += 1;
+            }
+            count.Should().Be(1);
+        }
+
+        [Test]
+        public void NullableNotHasValueFilter()
+        {
+            connection.Run(testTable3.Insert(new TestObject3() { Id = 1, Value_Int_Nullable = 100}));
+            connection.Run(testTable3.Insert(new TestObject3() { Id = 2, Value_Int_Nullable = null }));
+
+            int count = 0;
+            foreach (var row in connection.Run(testTable3.Filter(o => !o.Value_Int_Nullable.HasValue)))
+            {
+                row.Id.Should().Be(2);
+                count += 1;
+            }
+            count.Should().Be(1);
+        }
+
+        [Test]
+        public void NullableHasValueFilter()
+        {
+            connection.Run(testTable3.Insert(new TestObject3() { Id = 1, Value_Int_Nullable = 100}));
+            connection.Run(testTable3.Insert(new TestObject3() { Id = 2, Value_Int_Nullable = null }));
+
+            int count = 0;
+            foreach (var row in connection.Run(testTable3.Filter(o => o.Value_Int_Nullable.HasValue)))
+            {
+                row.Id.Should().Be(1);
+                count += 1;
+            }
+            count.Should().Be(1);
         }
     }
 }

--- a/rethinkdb-net/Connection.cs
+++ b/rethinkdb-net/Connection.cs
@@ -42,7 +42,8 @@ namespace RethinkDb
                     NullableDatumConverterFactory.Instance,
                     ListDatumConverterFactory.Instance,
                     TimeSpanDatumConverterFactory.Instance,
-                    GroupingDictionaryDatumConverterFactory.Instance
+                    GroupingDictionaryDatumConverterFactory.Instance,
+                    ObjectDatumConverterFactory.Instance
                 ),
                 new Expressions.DefaultExpressionConverterFactory()
             );

--- a/rethinkdb-net/DatumConverters/ObjectDatumConverterFactory.cs
+++ b/rethinkdb-net/DatumConverters/ObjectDatumConverterFactory.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using RethinkDb.Spec;
+
+namespace RethinkDb.DatumConverters
+{
+    public class ObjectDatumConverterFactory : AbstractDatumConverterFactory
+    {
+        public static readonly ObjectDatumConverterFactory Instance = new ObjectDatumConverterFactory();
+
+        private ObjectDatumConverterFactory()
+        {
+        }
+
+        public override bool TryGet<T>(IDatumConverterFactory rootDatumConverterFactory, out IDatumConverter<T> datumConverter)
+        {
+            datumConverter = null;
+
+            if (typeof(T) == typeof(Object))
+                datumConverter = (IDatumConverter<T>)ObjectDatumConverter.Instance.Value;
+
+            return datumConverter != null;
+        }
+    }
+
+    public class ObjectDatumConverter : AbstractReferenceTypeDatumConverter<Object>
+    {
+        public static readonly Lazy<ObjectDatumConverter> Instance = new Lazy<ObjectDatumConverter>(() => new ObjectDatumConverter());
+
+        #region IDatumConverter<Uri> Members
+
+        public override Object ConvertDatum(Spec.Datum datum)
+        {
+            if (datum.type == Datum.DatumType.R_NULL)
+                return null;
+
+            // What to do here... I don't know why someone would be doing this in the first place, we really only expected
+            // to return null here.  Maybe it should be polymorphic behavior; return the best matching type for the
+            // datum?
+            throw new Exception("Not able to convert non-null Datum to an Object");
+        }
+
+        public override Spec.Datum ConvertObject(Object obj)
+        {                
+            if (obj == null)
+                return new Datum() { type = Datum.DatumType.R_NULL };
+
+            // Again, maybe this should be some polymorphic behavior?
+            throw new Exception("Not able to convert non-null Object to a ReQL datum");
+        }
+
+        #endregion
+    }
+}

--- a/rethinkdb-net/Expressions/DefaultExpressionConverterFactory.cs
+++ b/rethinkdb-net/Expressions/DefaultExpressionConverterFactory.cs
@@ -25,6 +25,7 @@ namespace RethinkDb.Expressions
 
         public DefaultExpressionConverterFactory()
         {
+            NullableExpressionConverters.RegisterOnConverterFactory(this);
             LinqExpressionConverters.RegisterOnConverterFactory(this);
             DateTimeExpressionConverters.RegisterOnConverterFactory(this);
             GuidExpressionConverters.RegisterOnConverterFactory(this);

--- a/rethinkdb-net/Expressions/NullableExpressionConverters.cs
+++ b/rethinkdb-net/Expressions/NullableExpressionConverters.cs
@@ -1,0 +1,21 @@
+﻿using RethinkDb.Spec;
+
+namespace RethinkDb.Expressions
+{
+    public static class NullableExpressionConverters
+    {
+        public static void RegisterOnConverterFactory(DefaultExpressionConverterFactory expressionConverterFactory)
+        {
+            expressionConverterFactory.RegisterTemplateMapping<int?, bool>(
+                v => v.HasValue,
+                v => new Term() {
+                    type = Term.TermType.NE,
+                    args = {
+                        v,
+                        new Term() { type = Term.TermType.DATUM, datum = new Datum() { type = Datum.DatumType.R_NULL } }
+                    }
+                }
+            );
+        }
+    }
+}

--- a/rethinkdb-net/rethinkdb-net.csproj
+++ b/rethinkdb-net/rethinkdb-net.csproj
@@ -220,6 +220,7 @@
     <Compile Include="QueryTerm\IndexStatusQuery.cs" />
     <Compile Include="QueryTerm\IndexWaitQuery.cs" />
     <Compile Include="Interfaces\IStreamingSequenceQuery.cs" />
+    <Compile Include="Expressions\NullableExpressionConverters.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/rethinkdb-net/rethinkdb-net.csproj
+++ b/rethinkdb-net/rethinkdb-net.csproj
@@ -221,6 +221,7 @@
     <Compile Include="QueryTerm\IndexWaitQuery.cs" />
     <Compile Include="Interfaces\IStreamingSequenceQuery.cs" />
     <Compile Include="Expressions\NullableExpressionConverters.cs" />
+    <Compile Include="DatumConverters\ObjectDatumConverterFactory.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
This PR addresses the reported issue #203, where comparison with null doesn't work correctly in Filter clauses.  There are three general cases that support were added for; comparing a Nullable&lt;T> to null, comparing a reference type to null, and using Nullable&lt;T>.HasValue.