### PR TITLE
Compatibility with RethinkDB 2.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ dependencies:
     - source /etc/lsb-release && echo "deb http://download.rethinkdb.com/apt $DISTRIB_CODENAME main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
     - wget -qO- http://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
     - sudo apt-get update
-    - sudo apt-get install rethinkdb=1.16.3~0precise
+    - sudo apt-get install rethinkdb=2.0.0+1~0precise
 
 test:
   override:

--- a/rethinkdb-net/Connection.cs
+++ b/rethinkdb-net/Connection.cs
@@ -463,6 +463,12 @@ namespace RethinkDb
 
                 switch (response.type)
                 {
+                    case Response.ResponseType.SUCCESS_SEQUENCE:
+                        // We're getting SUCCESS_SEQUENCE on the STOP since RethinkDB 2.0 of changes queries.  Last
+                        // records of the change stream that were pending to be sent to us, perhaps?  Since this
+                        // enumerator is being disposed, we're not going to return them.  But this suggests we might
+                        // need a "StopStreaming" method, after which we could read the last values, and then dispose
+                        // the enumerator.
                     case Response.ResponseType.SUCCESS_ATOM:
                         break;
                     case Response.ResponseType.CLIENT_ERROR:


### PR DESCRIPTION
Compatibility with running unit tests and library against RethinkDB 2.0.  Does not include support for new features, which will be addressed w/ #194.