### PR TITLE
Can't access members of objects other than the function parameter

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -6,6 +6,8 @@
 
 * Supports RethinkDB's regular expression matching of strings, eg. ```table.Filter(o => o.Email != null && o.Email.Match(".*@(.*)") != null)```.  [Issue #107](https://github.com/mfenniak/rethinkdb-net/issues/107) & [PR #208](https://github.com/mfenniak/rethinkdb-net/pull/208)
 
+* Expressions can now reference member variables of server-side calculated data, eg. ```table.Filter(o => o.Email.Match(".*@(.*)").Groups[0].MatchedString == "google.com")``` would filter for all records with an e-mail address that has a domain of "google.com".  [PR #209](https://github.com/mfenniak/rethinkdb-net/pull/209)
+
 
 ## 0.10.0.0 (2015-04-14)
 

--- a/rethinkdb-net-test/Integration/MultiObjectTests.cs
+++ b/rethinkdb-net-test/Integration/MultiObjectTests.cs
@@ -1133,5 +1133,20 @@ namespace RethinkDb.Test.Integration
             }
             count.Should().Be(1);
         }
+
+        [Test]
+        public void FilterByRegexpGroup()
+        {
+            int count = 0;
+            foreach (var row in connection.Run(testTable.Filter(o => 
+                o.Name.Match("^([3])$") != null &&
+                o.Name.Match("^([3])$").Groups[0].MatchedString == "3"
+            )))
+            {
+                row.Name.Should().Be("3");
+                count += 1;
+            }
+            count.Should().Be(1);
+        }
     }
 }

--- a/rethinkdb-net/DatumConverters/AnonymousTypeDatumConverterFactory.cs
+++ b/rethinkdb-net/DatumConverters/AnonymousTypeDatumConverterFactory.cs
@@ -30,7 +30,7 @@ namespace RethinkDb.DatumConverters
 
         public bool IsTypeSupported(Type t)
         {
-            if (t.IsClass && t.Name.Contains("Anon") && t.Name.StartsWith("<>") && t.GetCustomAttributes(typeof(CompilerGeneratedAttribute), false).Length == 1)
+            if (t.IsClass && t.Name.Contains("Anon") && t.GetCustomAttributes(typeof(CompilerGeneratedAttribute), false).Length == 1)
                 return true;
             return false;
         }

--- a/rethinkdb-net/DatumConverters/AnonymousTypeDatumConverterFactory.cs
+++ b/rethinkdb-net/DatumConverters/AnonymousTypeDatumConverterFactory.cs
@@ -30,7 +30,7 @@ namespace RethinkDb.DatumConverters
 
         public bool IsTypeSupported(Type t)
         {
-            if (t.IsClass && t.Name.Contains("Anon") && t.GetCustomAttributes(typeof(CompilerGeneratedAttribute), false).Length == 1)
+            if (t.IsClass && t.Name.Contains("Anon") && t.Name.StartsWith("<>") && t.GetCustomAttributes(typeof(CompilerGeneratedAttribute), false).Length == 1)
                 return true;
             return false;
         }

--- a/rethinkdb-net/Expressions/TwoParameterLambda.cs
+++ b/rethinkdb-net/Expressions/TwoParameterLambda.cs
@@ -136,113 +136,30 @@ namespace RethinkDb.Expressions
                         }
                     };
                 }
-
-                case ExpressionType.MemberAccess:
+                
+                case ExpressionType.Convert:
                 {
-                    var memberExpr = (MemberExpression)expr;
-                    var member = memberExpr.Member;
-                    ParameterExpression parameterExpr = null;
+                    // In some cases the CLR can insert a type-cast when a generic type constrant is present on a
+                    // generic type that's a parameter.  We pretty much just ignore those casts.  It might be
+                    // valid to use the cast to switch to a different datum converter?, but the use-case isn't
+                    // really clear right now.  We do check that the type-cast makes sense for the parameter type,
+                    // but it's just to feel safer; it seems like the compiler should've made sure about that.
 
-                    if (memberExpr.Expression == null)
-                    {
+                    var convertExpression = (UnaryExpression)expr;
+                    if (convertExpression.Operand.NodeType != ExpressionType.Parameter)
+                        // If this isn't a cast on a Parameter, just drop it through to do continue processing.
                         return SimpleMap(datumConverterFactory, expr);
-                    }
-                    else if (memberExpr.Expression.NodeType == ExpressionType.Convert)
-                    {
-                        // In some cases the CLR can insert a type-cast when a generic type constrant is present on a
-                        // generic type that's a parameter.  We pretty much just ignore those casts.  It might be
-                        // valid to use the cast to switch to a different datum converter?, but the use-case isn't
-                        // really clear right now.  We do check that the type-cast makes sense for the parameter type,
-                        // but it's just to feel safer; it seems like the compiler should've made sure about that.
 
-                        var convertExpression = (UnaryExpression)memberExpr.Expression;
-                        if (convertExpression.Operand.NodeType != ExpressionType.Parameter)
-                            return SimpleMap(datumConverterFactory, expr);
+                    // Otherwise; type-check it, and then just strip the Convert node out and recursivemap the inside.
+                    var parameterExpr = (ParameterExpression)convertExpression.Operand;
+                    if (!convertExpression.Type.IsAssignableFrom(parameterExpr.Type))
+                        throw new NotSupportedException(String.Format(
+                            "Cast on parameter expression not currently supported (from type {0} to type {1})",
+                            parameterExpr.Type, convertExpression.Type));
 
-                        parameterExpr = (ParameterExpression)convertExpression.Operand;
-                        if (!convertExpression.Type.IsAssignableFrom(parameterExpr.Type))
-                            throw new NotSupportedException(String.Format(
-                                "Cast on parameter expression not currently supported (from type {0} to type {1})",
-                                parameterExpr.Type, convertExpression.Type));
-                    }
-                    else if (memberExpr.Expression.NodeType != ExpressionType.Parameter)
-                    {
-                        return SimpleMap(datumConverterFactory, expr);
-                    }
-
-                    DefaultExpressionConverterFactory.ExpressionMappingDelegate<MemberExpression> memberAccessMapping;
-                    if (expressionConverterFactory.TryGetMemberAccessMapping(member, out memberAccessMapping))
-                        return memberAccessMapping(memberExpr, RecursiveMap, datumConverterFactory, expressionConverterFactory);
-
-                    if (parameterExpr == null)
-                        parameterExpr = (ParameterExpression)memberExpr.Expression;
-                    int parameterIndex;
-                    if (parameterExpr.Name == parameter1Name)
-                        parameterIndex = 3;
-                    else if (parameterExpr.Name == parameter2Name)
-                        parameterIndex = 4;
-                    else
-                        throw new InvalidOperationException("Unmatched parameter name:" + parameterExpr.Name);
-
-                    var getAttrTerm = new Term() {
-                        type = Term.TermType.GET_FIELD
-                    };
-
-                    getAttrTerm.args.Add(new Term() {
-                        type = Term.TermType.VAR,
-                        args = {
-                            new Term() {
-                                type = Term.TermType.DATUM,
-                                datum = new Datum() {
-                                    type = Datum.DatumType.R_NUM,
-                                    r_num = parameterIndex
-                                },
-                            }
-                        }
-                    });
-
-                    if (parameterIndex == 3)
-                    {
-                        var datumConverter = datumConverterFactory.Get<TParameter1>();
-                        var fieldConverter = datumConverter as IObjectDatumConverter;
-                        if (fieldConverter == null)
-                            throw new NotSupportedException("Cannot map member access into ReQL without implementing IObjectDatumConverter");
-
-                        var datumFieldName = fieldConverter.GetDatumFieldName(memberExpr.Member);
-                        if (string.IsNullOrEmpty(datumFieldName))
-                            throw new NotSupportedException(String.Format("Member {0} on type {1} could not be mapped to a datum field", memberExpr.Member.Name, memberExpr.Type));
-
-                        getAttrTerm.args.Add(new Term() {
-                            type = Term.TermType.DATUM,
-                            datum = new Datum() {
-                                type = Datum.DatumType.R_STR,
-                                r_str = datumFieldName
-                            }
-                        });
-                    }
-                    else if (parameterIndex == 4)
-                    {
-                        var datumConverter = datumConverterFactory.Get<TParameter2>();
-                        var fieldConverter = datumConverter as IObjectDatumConverter;
-                        if (fieldConverter == null)
-                            throw new NotSupportedException("Cannot map member access into ReQL without implementing IObjectDatumConverter");
-
-                        var datumFieldName = fieldConverter.GetDatumFieldName(memberExpr.Member);
-                        if (string.IsNullOrEmpty(datumFieldName))
-                            throw new NotSupportedException(String.Format("Member {0} on type {1} could not be mapped to a datum field", memberExpr.Member.Name, memberExpr.Type));
-
-                        getAttrTerm.args.Add(new Term() {
-                            type = Term.TermType.DATUM,
-                            datum = new Datum() {
-                                type = Datum.DatumType.R_STR,
-                                r_str = datumFieldName
-                            }
-                        });
-                    }
-
-                    return getAttrTerm;
+                    return RecursiveMap(parameterExpr);
                 }
-
+                
                 default:
                     return SimpleMap(datumConverterFactory, expr);
             }


### PR DESCRIPTION
Some attempts to access a member of an object in a LINQ expression tree, other than the parameter, don't work.  In particular, using the new regex match operator from #107 and then accessing fields on the result don't work.  This seems to be caused by BaseExpression.cs only supporting static members, not any random expression type for which a IObjectDatumConverter is available.

First attempt to fix this caused an issue where anonymous types that could & should be evaluated client-side are turning into server-side serialized objects.  In particular, variables referenced from the function scope by a delegate.  Was able to address this with a hack in the AnonymousTypeDatumConverterFactory, but that doesn't fix the same problem on the newtonsoft converters.

Needs further work.