### PR TITLE
Finish up incomplete parts of edges of changefeed support

### DIFF
--- a/Examples/RethinkDb.Examples.ConsoleApp/Person.cs
+++ b/Examples/RethinkDb.Examples.ConsoleApp/Person.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.Serialization;
+using RethinkDb.QueryTerm;
 
 namespace RethinkDb.Examples.ConsoleApp
 {
@@ -7,7 +8,7 @@ namespace RethinkDb.Examples.ConsoleApp
     public class Person
     {
         public static IDatabaseQuery Db = Query.Db("test");
-        public static ITableQuery<Person> Table = Db.Table<Person>("people");
+        public static TableQuery<Person> Table = Db.Table<Person>("people");
 
         [DataMember(Name = "id", EmitDefaultValue = false)]
         public Guid Id;
@@ -16,4 +17,3 @@ namespace RethinkDb.Examples.ConsoleApp
         public string Name;
     }
 }
-

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -12,6 +12,8 @@
 
 * Added changefeed support for ordering by an index and limiting the result set, eg. ```table.OrderBy(...index...).Limit(1)``` will return all changes to the smallest record in the index.  [PR #210](https://github.com/mfenniak/rethinkdb-net/pull/210)
 
+* Added changefeed support for union queries.  [PR #210](https://github.com/mfenniak/rethinkdb-net/pull/210)
+
 
 ## 0.10.0.0 (2015-04-14)
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -14,6 +14,8 @@
 
 * Added changefeed support for union queries.  [PR #210](https://github.com/mfenniak/rethinkdb-net/pull/210)
 
+* Added changefeed support for min and max queries against an index.  [PR #210](https://github.com/mfenniak/rethinkdb-net/pull/210)
+
 
 ## 0.10.0.0 (2015-04-14)
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -8,6 +8,10 @@
 
 * Expressions can now reference member variables of server-side calculated data, eg. ```table.Filter(o => o.Email.Match(".*@(.*)").Groups[0].MatchedString == "google.com")``` would filter for all records with an e-mail address that has a domain of "google.com".  [PR #209](https://github.com/mfenniak/rethinkdb-net/pull/209)
 
+* Added changefeed support for point / single-document changefeed, eg. ```table.Get(...key...).Changes()```.  [Issue #197](https://github.com/mfenniak/rethinkdb-net/issues/197) & [PR #210](https://github.com/mfenniak/rethinkdb-net/pull/210)
+
+* Added changefeed support for ordering by an index and limiting the result set, eg. ```table.OrderBy(...index...).Limit(1)``` will return all changes to the smallest record in the index.  [PR #210](https://github.com/mfenniak/rethinkdb-net/pull/210)
+
 
 ## 0.10.0.0 (2015-04-14)
 

--- a/rethinkdb-net-test/Integration/MultiObjectTests.cs
+++ b/rethinkdb-net-test/Integration/MultiObjectTests.cs
@@ -1148,5 +1148,21 @@ namespace RethinkDb.Test.Integration
             }
             count.Should().Be(1);
         }
+
+        [Test]
+        public void MinIndexAggregate()
+        {
+            var minName = connection.Run(testTable.Min(nameIndex));
+            minName.Should().NotBeNull();
+            minName.Name.Should().Be("1");
+        }
+
+        [Test]
+        public void MaxIndexAggregate()
+        {
+            var maxName = connection.Run(testTable.Max(nameIndex));
+            maxName.Should().NotBeNull();
+            maxName.Name.Should().Be("7");
+        }
     }
 }

--- a/rethinkdb-net-test/Integration/RealtimePushTests.cs
+++ b/rethinkdb-net-test/Integration/RealtimePushTests.cs
@@ -331,20 +331,24 @@ namespace RethinkDb.Test.Integration
             );
         }
 
-        /*
-         * Min / Max operations on indexes not currently supported, but should be; issue #198
-
         [Test]
         [Timeout(30000)]
         public void ChangesWithMin()
         {
-            RealtimePushTestSingleResponse(
-                () => testTable.Min(someNumberIndex).Changes(),
+            RealtimePushTestTwoResponses(
+                () => testTable.Min(testSomeNumberIndex).Changes(),
                 () =>
                 {
                     var result = connection.Run(testTable.Get("3").Update(o => new TestObject() { SomeNumber = -100 }));
                     result.Should().NotBeNull();
-                    result.Replaced.Should().Be(1.0);
+                    result.Replaced.Should().Be(1);
+                },
+                response =>
+                {
+                    // .Min().Changes() sends the initial value as the first streaming result
+                    response.OldValue.Should().BeNull();
+                    response.NewValue.Id.Should().Be("1");
+                    response.NewValue.SomeNumber.Should().Be(1);
                 },
                 response =>
                 {
@@ -360,13 +364,20 @@ namespace RethinkDb.Test.Integration
         [Timeout(30000)]
         public void ChangesWithMax()
         {
-            RealtimePushTestSingleResponse(
-                () => testTable.Max(someNumberIndex).Changes(),
+            RealtimePushTestTwoResponses(
+                () => testTable.Max(testSomeNumberIndex).Changes(),
                 () =>
                 {
                     var result = connection.Run(testTable.Get("3").Update(o => new TestObject() { SomeNumber = 100 }));
                     result.Should().NotBeNull();
-                    result.Replaced.Should().Be(1.0);
+                    result.Replaced.Should().Be(1);
+                },
+                response =>
+                {
+                // .Max().Changes() sends the initial value as the first streaming result
+                    response.OldValue.Should().BeNull();
+                    response.NewValue.Id.Should().Be("7");
+                    response.NewValue.SomeNumber.Should().Be(7);
                 },
                 response =>
                 {
@@ -377,6 +388,5 @@ namespace RethinkDb.Test.Integration
                 }
             );
         }
-        */
     }
 }

--- a/rethinkdb-net-test/Integration/RealtimePushTests.cs
+++ b/rethinkdb-net-test/Integration/RealtimePushTests.cs
@@ -311,6 +311,26 @@ namespace RethinkDb.Test.Integration
             );
         }
 
+        [Test]
+        [Timeout(30000)]
+        public void ChangesWithUnion()
+        {
+            RealtimePushTestSingleResponse(
+                () => testTable.Filter(o => o.Name == "2").Union(testTable.Filter(o => o.Name == "3")).Changes(),
+                () =>
+                {
+                    var result = connection.Run(testTable.Get("3").Update(o => new TestObject() { Name = "Updated!" }));
+                    result.Should().NotBeNull();
+                    result.Replaced.Should().Be(1);
+                },
+                response =>
+                {
+                    response.OldValue.Name.Should().Be("3");
+                    response.NewValue.Should().BeNull(); // because the old record doesn't match the filter condition anymore
+                }
+            );
+        }
+
         /*
          * Min / Max operations on indexes not currently supported, but should be; issue #198
 

--- a/rethinkdb-net-test/Integration/RealtimePushTests.cs
+++ b/rethinkdb-net-test/Integration/RealtimePushTests.cs
@@ -5,13 +5,14 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using NUnit.Framework;
 using RethinkDb;
+using RethinkDb.QueryTerm;
 
 namespace RethinkDb.Test.Integration
 {
     [TestFixture]
     public class RealtimePushTests : TestBase
     {
-        private ITableQuery<TestObject> testTable;
+        private TableQuery<TestObject> testTable;
 
         public override void TestFixtureSetUp()
         {
@@ -101,6 +102,72 @@ namespace RethinkDb.Test.Integration
             e2.Should().BeNull();
         }
 
+        private void RealtimePushTestTwoResponses<T>(
+            Func<IStreamingSequenceQuery<DmlResponseChange<T>>> createStreamingQuery,
+            Action doModifications,
+            Action<DmlResponseChange<T>> verifyFirstStreamingResult,
+            Action<DmlResponseChange<T>> verifySecondStreamingResult)
+        {
+            Exception e1 = null;
+            Exception e2 = null;
+
+            ManualResetEvent sync1 = new ManualResetEvent(false);
+
+            var thread1 = new Thread(() =>
+            {
+                try
+                {
+                    var query = createStreamingQuery();
+                    IAsyncEnumerator<DmlResponseChange<T>> enumerator = null;
+                    try
+                    {
+                        enumerator = connection.StreamChangesAsync(query);
+                        var task = enumerator.MoveNext();
+                        sync1.Set(); // inform other thread that we're ready for it to make changes
+
+                        task.Wait();
+                        task.Result.Should().BeTrue();
+                        verifyFirstStreamingResult(enumerator.Current);
+
+                        task = enumerator.MoveNext();
+                        task.Wait();
+                        task.Result.Should().BeTrue();
+                        verifySecondStreamingResult(enumerator.Current);
+                    }
+                    finally
+                    {
+                        enumerator.Dispose().Wait();
+                    }
+                }
+                catch (Exception e)
+                {
+                    e1 = e;
+                }
+            });
+
+            var thread2 = new Thread(() =>
+            {
+                try
+                {
+                    sync1.WaitOne();
+                    doModifications();
+                }
+                catch (Exception e)
+                {
+                    e2 = e;
+                }
+            });
+
+            thread1.Start();
+            thread2.Start();
+
+            thread1.Join();
+            thread2.Join();
+
+            e1.Should().BeNull();
+            e2.Should().BeNull();
+        }
+
         // Changes on a single record not currently supported by rethinkdb-net, but should be; issue #197.
         //[Test]
         //public void ChangesOnPrimaryKey()
@@ -109,6 +176,35 @@ namespace RethinkDb.Test.Integration
         //    {
         //    }
         //}
+
+        [Test]
+        [Timeout(30000)]
+        public void ChangesWithPrimaryKey()
+        {
+            RealtimePushTestTwoResponses(
+                () => testTable.Get("3").Changes(),
+                () =>
+                {
+                    var result = connection.Run(testTable.Get("3").Update(o => new TestObject() { Name = "Updated!" }));
+                    result.Should().NotBeNull();
+                    result.Replaced.Should().Be(1);
+                },
+                response =>
+                {
+                    // .Get().Changes() sends the initial value as the first streaming result
+                    response.OldValue.Should().BeNull();
+                    response.NewValue.Should().NotBeNull();
+                    response.NewValue.Name.Should().Be("3");
+                },
+                response =>
+                {
+                    response.OldValue.Should().NotBeNull();
+                    response.OldValue.Name.Should().Be("3");
+                    response.NewValue.Should().NotBeNull();
+                    response.NewValue.Name.Should().Be("Updated!");
+                }
+            );
+        }
 
         [Test]
         [Timeout(30000)]
@@ -190,6 +286,7 @@ namespace RethinkDb.Test.Integration
             );
         }
 
+        /*
         [Test]
         [Timeout(30000)]
         [Ignore("Fails due to RethinkDB error 'cannot call changes on an eager stream' despite RethinkdB 1.16 documentation claiming this should work")]
@@ -212,6 +309,7 @@ namespace RethinkDb.Test.Integration
                 }
             );
         }
+        */
 
         /*
          * Min / Max operations on indexes not currently supported, but should be; issue #198

--- a/rethinkdb-net/Interfaces/IChangefeedCompatibleQuery.cs
+++ b/rethinkdb-net/Interfaces/IChangefeedCompatibleQuery.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.ComponentModel;
-using RethinkDb.Spec;
 
 namespace RethinkDb
 {
     [ImmutableObject(true)]
-    public interface ITableQuery<T> : ISequenceQuery<T>
+    public interface IChangefeedCompatibleQuery<T> : IQuery
     {
     }
 }

--- a/rethinkdb-net/Interfaces/IOrderByIndexQuery.cs
+++ b/rethinkdb-net/Interfaces/IOrderByIndexQuery.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace RethinkDb
+{
+    public interface IOrderByIndexQuery<T> : ISequenceQuery<T>
+    {
+    }
+}

--- a/rethinkdb-net/Query.cs
+++ b/rethinkdb-net/Query.cs
@@ -12,22 +12,22 @@ namespace RethinkDb
     {
         #region Database Operations
 
-        public static IDatabaseQuery Db(string db)
+        public static DbQuery Db(string db)
         {
             return new DbQuery(db);
         }
 
-        public static IWriteQuery<DmlResponse> DbCreate(string db)
+        public static DbCreateQuery DbCreate(string db)
         {
             return new DbCreateQuery(db);
         }
 
-        public static IWriteQuery<DmlResponse> DbDrop(string db)
+        public static DbDropQuery DbDrop(string db)
         {
             return new DbDropQuery(db);
         }
 
-        public static ISingleObjectQuery<string[]> DbList()
+        public static DbListQuery DbList()
         {
             return new DbListQuery();
         }
@@ -35,47 +35,47 @@ namespace RethinkDb
         #endregion
         #region Table Operations
 
-        public static ITableQuery<T> Table<T>(this IDatabaseQuery target, string table, bool useOutdated = false)
+        public static TableQuery<T> Table<T>(this IDatabaseQuery target, string table, bool useOutdated = false)
         {
             return new TableQuery<T>(target, table, useOutdated);
         }
 
-        public static IWriteQuery<DmlResponse> TableCreate(this IDatabaseQuery target, string table, string datacenter = null, string primaryKey = null, double? cacheSize = null)
+        public static TableCreateQuery TableCreate(this IDatabaseQuery target, string table, string datacenter = null, string primaryKey = null, double? cacheSize = null)
         {
             return new TableCreateQuery(target, table, datacenter, primaryKey, cacheSize);
         }
 
-        public static IWriteQuery<DmlResponse> TableDrop(this IDatabaseQuery target, string table)
+        public static TableDropQuery TableDrop(this IDatabaseQuery target, string table)
         {
             return new TableDropQuery(target, table);
         }
 
-        public static ISingleObjectQuery<string[]> TableList(this IDatabaseQuery target)
+        public static TableListQuery TableList(this IDatabaseQuery target)
         {
             return new TableListQuery(target);
         }
 
-        public static IWriteQuery<DmlResponse> IndexCreate<T, TIndexExpression>(this ITableQuery<T> target, string indexName, Expression<Func<T, TIndexExpression>> indexExpression, bool multiIndex = false)
+        public static IndexCreateQuery<T, TIndexExpression> IndexCreate<T, TIndexExpression>(this ITableQuery<T> target, string indexName, Expression<Func<T, TIndexExpression>> indexExpression, bool multiIndex = false)
         {
             return new IndexCreateQuery<T, TIndexExpression>(target, indexName, indexExpression, multiIndex);
         }
 
-        public static ISequenceQuery<IndexStatus> IndexWait<T>(this ITableQuery<T> target, params string[] indexNames)
+        public static IndexWaitQuery<T> IndexWait<T>(this ITableQuery<T> target, params string[] indexNames)
         {
             return new IndexWaitQuery<T>(target, indexNames);
         }
 
-        public static ISequenceQuery<IndexStatus> IndexStatus<T>(this ITableQuery<T> target, params string[] indexNames)
+        public static IndexStatusQuery<T> IndexStatus<T>(this ITableQuery<T> target, params string[] indexNames)
         {
             return new IndexStatusQuery<T>(target, indexNames);
         }
 
-        public static ISequenceQuery<string> IndexList<T>(this ITableQuery<T> target)
+        public static IndexListQuery<T> IndexList<T>(this ITableQuery<T> target)
         {
             return new IndexListQuery<T>(target);
         }
 
-        public static IWriteQuery<DmlResponse> IndexDrop<T>(this ITableQuery<T> target, string indexName)
+        public static IndexDropQuery<T> IndexDrop<T>(this ITableQuery<T> target, string indexName)
         {
             return new IndexDropQuery<T>(target, indexName);
         }
@@ -90,17 +90,17 @@ namespace RethinkDb
             return new MultiIndex<TRecord, TIndex>(table, name, indexAccessor);
         }
 
-        public static IWriteQuery<DmlResponse> IndexCreate<TRecord, TIndex>(this IIndex<TRecord, TIndex> index)
+        public static IndexCreateQuery<TRecord, TIndex> IndexCreate<TRecord, TIndex>(this IIndex<TRecord, TIndex> index)
         {
             return index.Table.IndexCreate(index.Name, index.IndexAccessor, false);
         }
 
-        public static IWriteQuery<DmlResponse> IndexCreate<TRecord, TIndex>(this IMultiIndex<TRecord, TIndex> index)
+        public static IndexCreateQuery<TRecord, IEnumerable<TIndex>> IndexCreate<TRecord, TIndex>(this IMultiIndex<TRecord, TIndex> index)
         {
             return index.Table.IndexCreate(index.Name, index.IndexAccessor, true);
         }
 
-        public static ISequenceQuery<IndexStatus> IndexStatus<TRecord, TIndex>(this IBaseIndex<TRecord, TIndex> index)
+        public static IndexStatusQuery<TRecord> IndexStatus<TRecord, TIndex>(this IBaseIndex<TRecord, TIndex> index)
         {
             // FIXME: Since this overload only takes a single index name, it'd be nice if we could return an
             // IScalarQuery... but we don't currently have a query op that takes a sequence and returns a
@@ -108,7 +108,7 @@ namespace RethinkDb
             return index.Table.IndexStatus(index.Name);
         }
 
-        public static ISequenceQuery<IndexStatus> IndexWait<TRecord, TIndex>(this IBaseIndex<TRecord, TIndex> index)
+        public static IndexWaitQuery<TRecord> IndexWait<TRecord, TIndex>(this IBaseIndex<TRecord, TIndex> index)
         {
             // FIXME: Since this overload only takes a single index name, it'd be nice if we could return an
             // IScalarQuery... but we don't currently have a query op that takes a sequence and returns a
@@ -116,22 +116,22 @@ namespace RethinkDb
             return index.Table.IndexWait(index.Name);
         }
 
-        public static IWriteQuery<DmlResponse> IndexDrop<TRecord, TIndex>(this IBaseIndex<TRecord, TIndex> index)
+        public static IndexDropQuery<TRecord> IndexDrop<TRecord, TIndex>(this IBaseIndex<TRecord, TIndex> index)
         {
             return index.Table.IndexDrop(index.Name);
         }
 
-        public static IWriteQuery<DmlResponse> Insert<T>(this ITableQuery<T> target, T @object, Conflict conflict = Conflict.Error)
+        public static InsertQuery<T> Insert<T>(this ITableQuery<T> target, T @object, Conflict conflict = Conflict.Error)
         {
             return new InsertQuery<T>(target, new T[] { @object }, conflict);
         }
 
-        public static IWriteQuery<DmlResponse> Insert<T>(this ITableQuery<T> target, IEnumerable<T> @objects, Conflict conflict = Conflict.Error)
+        public static InsertQuery<T> Insert<T>(this ITableQuery<T> target, IEnumerable<T> @objects, Conflict conflict = Conflict.Error)
         {
             return new InsertQuery<T>(target, @objects, conflict);
         }
 
-        public static IStreamingSequenceQuery<DmlResponseChange<TRecord>> Changes<TRecord>(this ISequenceQuery<TRecord> target)
+        public static ChangesQuery<TRecord> Changes<TRecord>(this IChangefeedCompatibleQuery<TRecord> target)
         {
             return new ChangesQuery<TRecord>(target);
         }
@@ -139,124 +139,124 @@ namespace RethinkDb
         #endregion
         #region Query Operations
 
-        public static IMutableSingleObjectQuery<T> Get<T>(this ISequenceQuery<T> target, string primaryKey, string primaryAttribute = null)
+        public static GetQuery<T> Get<T>(this ISequenceQuery<T> target, string primaryKey, string primaryAttribute = null)
         {
             return new GetQuery<T>(target, primaryKey, primaryAttribute);
         }
 
-        public static IMutableSingleObjectQuery<T> Get<T>(this ISequenceQuery<T> target, double primaryKey, string primaryAttribute = null)
+        public static GetQuery<T> Get<T>(this ISequenceQuery<T> target, double primaryKey, string primaryAttribute = null)
         {
             return new GetQuery<T>(target, primaryKey, primaryAttribute);
         }
 
-        public static ISequenceQuery<TSequence> GetAll<TSequence, TKey>(this ISequenceQuery<TSequence> target, TKey key, string indexName = null)
+        public static GetAllQuery<TSequence, TKey> GetAll<TSequence, TKey>(this ISequenceQuery<TSequence> target, TKey key, string indexName = null)
         {
             return new GetAllQuery<TSequence, TKey>(target, new TKey[] { key }, indexName);
         }
 
-        public static ISequenceQuery<TSequence> GetAll<TSequence, TKey>(this ISequenceQuery<TSequence> target, TKey[] keys, string indexName = null)
+        public static GetAllQuery<TSequence, TKey> GetAll<TSequence, TKey>(this ISequenceQuery<TSequence> target, TKey[] keys, string indexName = null)
         {
             return new GetAllQuery<TSequence, TKey>(target, keys, indexName);
         }
 
-        public static ISequenceQuery<TSequence> GetAll<TSequence, TKey>(this ISequenceQuery<TSequence> target, TKey key, IBaseIndex<TSequence, TKey> index)
+        public static GetAllQuery<TSequence, TKey> GetAll<TSequence, TKey>(this ISequenceQuery<TSequence> target, TKey key, IBaseIndex<TSequence, TKey> index)
         {
             return target.GetAll(key, indexName: index.Name);
         }
 
-        public static ISequenceQuery<TSequence> GetAll<TSequence, TKey>(this IBaseIndex<TSequence, TKey> index, params TKey[] keys)
+        public static GetAllQuery<TSequence, TKey> GetAll<TSequence, TKey>(this IBaseIndex<TSequence, TKey> index, params TKey[] keys)
         {
             return index.Table.GetAll(keys: keys, indexName: index.Name);
         }
 
-        public static ISequenceQuery<T> Filter<T>(this ISequenceQuery<T> target, Expression<Func<T, bool>> filterExpression)
+        public static FilterQuery<T> Filter<T>(this ISequenceQuery<T> target, Expression<Func<T, bool>> filterExpression)
         {
             return new FilterQuery<T>(target, filterExpression);
         }
 
         // LINQ-compatible alias for Filter
-        public static ISequenceQuery<T> Where<T>(this ISequenceQuery<T> target, Expression<Func<T, bool>> filterExpression)
+        public static FilterQuery<T> Where<T>(this ISequenceQuery<T> target, Expression<Func<T, bool>> filterExpression)
         {
             return target.Filter(filterExpression);
         }
 
-        public static IWriteQuery<DmlResponse> Update<T>(this ISequenceQuery<T> target, Expression<Func<T, T>> updateExpression, bool nonAtomic = false)
+        public static UpdateQuery<T> Update<T>(this ISequenceQuery<T> target, Expression<Func<T, T>> updateExpression, bool nonAtomic = false)
         {
             return new UpdateQuery<T>(target, updateExpression, nonAtomic);
         }
 
-        public static IWriteQuery<DmlResponse> Update<T>(this IMutableSingleObjectQuery<T> target, Expression<Func<T, T>> updateExpression, bool nonAtomic = false)
+        public static UpdateQuery<T> Update<T>(this IMutableSingleObjectQuery<T> target, Expression<Func<T, T>> updateExpression, bool nonAtomic = false)
         {
             return new UpdateQuery<T>(target, updateExpression, nonAtomic);
         }
 
-        public static IWriteQuery<DmlResponse<T>> UpdateAndReturnChanges<T>(this IMutableSingleObjectQuery<T> target, Expression<Func<T, T>> updateExpression, bool nonAtomic = false)
+        public static UpdateAndReturnValueQuery<T> UpdateAndReturnChanges<T>(this IMutableSingleObjectQuery<T> target, Expression<Func<T, T>> updateExpression, bool nonAtomic = false)
         {
             return new UpdateAndReturnValueQuery<T>(target, updateExpression, nonAtomic);
         }
 
-        public static IWriteQuery<DmlResponse> Delete<T>(this ISequenceQuery<T> target)
+        public static DeleteQuery<T> Delete<T>(this ISequenceQuery<T> target)
         {
             return new DeleteQuery<T>(target);
         }
 
-        public static IWriteQuery<DmlResponse> Delete<T>(this IMutableSingleObjectQuery<T> target)
+        public static DeleteQuery<T> Delete<T>(this IMutableSingleObjectQuery<T> target)
         {
             return new DeleteQuery<T>(target);
         }
 
-        public static IWriteQuery<DmlResponse<T>> DeleteAndReturnChanges<T>(this IMutableSingleObjectQuery<T> target)
+        public static DeleteAndReturnValueQuery<T> DeleteAndReturnChanges<T>(this IMutableSingleObjectQuery<T> target)
         {
             return new DeleteAndReturnValueQuery<T>(target);
         }
 
-        public static IWriteQuery<DmlResponse> Replace<T>(this IMutableSingleObjectQuery<T> target, T newObject, bool nonAtomic = false)
+        public static ReplaceQuery<T> Replace<T>(this IMutableSingleObjectQuery<T> target, T newObject, bool nonAtomic = false)
         {
             return new ReplaceQuery<T>(target, newObject, nonAtomic);
         }
 
-        public static IWriteQuery<DmlResponse<T>> ReplaceAndReturnChanges<T>(this IMutableSingleObjectQuery<T> target, T newObject, bool nonAtomic = false)
+        public static ReplaceAndReturnValueQuery<T> ReplaceAndReturnChanges<T>(this IMutableSingleObjectQuery<T> target, T newObject, bool nonAtomic = false)
         {
             return new ReplaceAndReturnValueQuery<T>(target, newObject, nonAtomic);
         }
 
-        public static ISequenceQuery<TSequence> Between<TSequence, TKey>(this ISequenceQuery<TSequence> target, TKey leftKey, TKey rightKey, string indexName = null, Bound leftBound = Bound.Closed, Bound rightBound = Bound.Open)
+        public static BetweenQuery<TSequence, TKey> Between<TSequence, TKey>(this ISequenceQuery<TSequence> target, TKey leftKey, TKey rightKey, string indexName = null, Bound leftBound = Bound.Closed, Bound rightBound = Bound.Open)
         {
             return new BetweenQuery<TSequence, TKey>(target, leftKey, rightKey, indexName, leftBound, rightBound);
         }
 
-        public static ISequenceQuery<TSequence> Between<TSequence, TKey>(this ISequenceQuery<TSequence> target, TKey leftKey, TKey rightKey, IBaseIndex<TSequence, TKey> index, Bound leftBound = Bound.Closed, Bound rightBound = Bound.Open)
+        public static BetweenQuery<TSequence, TKey> Between<TSequence, TKey>(this ISequenceQuery<TSequence> target, TKey leftKey, TKey rightKey, IBaseIndex<TSequence, TKey> index, Bound leftBound = Bound.Closed, Bound rightBound = Bound.Open)
         {
             return target.Between(leftKey, rightKey, index.Name, leftBound, rightBound);
         }
 
-        public static ISingleObjectQuery<T> Expr<T>(T @object)
+        public static ExprQuery<T> Expr<T>(T @object)
         {
             return new ExprQuery<T>(@object);
         }
 
-        public static ISingleObjectQuery<T> Expr<T>(Expression<Func<T>> objectExpr)
+        public static ExprQuery<T> Expr<T>(Expression<Func<T>> objectExpr)
         {
             return new ExprQuery<T>(objectExpr);
         }
 
-        public static ISequenceQuery<T> Expr<T>(IEnumerable<T> enumerable)
+        public static ExprSequenceQuery<T> Expr<T>(IEnumerable<T> enumerable)
         {
             return new ExprSequenceQuery<T>(enumerable);
         }
 
-        public static ISequenceQuery<TTarget> Map<TOriginal, TTarget>(this ISequenceQuery<TOriginal> sequenceQuery, Expression<Func<TOriginal, TTarget>> mapExpression)
+        public static MapQuery<TOriginal, TTarget> Map<TOriginal, TTarget>(this ISequenceQuery<TOriginal> sequenceQuery, Expression<Func<TOriginal, TTarget>> mapExpression)
         {
             return new MapQuery<TOriginal, TTarget>(sequenceQuery, mapExpression);
         }
 
         // LINQ-compatible alias for Map
-        public static ISequenceQuery<TTarget> Select<TOriginal, TTarget>(this ISequenceQuery<TOriginal> sequenceQuery, Expression<Func<TOriginal, TTarget>> mapExpression)
+        public static MapQuery<TOriginal, TTarget> Select<TOriginal, TTarget>(this ISequenceQuery<TOriginal> sequenceQuery, Expression<Func<TOriginal, TTarget>> mapExpression)
         {
             return sequenceQuery.Map(mapExpression);
         }
 
-        public static IOrderedSequenceQuery<T> OrderBy<T>(
+        public static OrderByQuery<T> OrderBy<T>(
             this ISequenceQuery<T> sequenceQuery,
             Expression<Func<T, object>> memberReferenceExpression,
             OrderByDirection direction = OrderByDirection.Ascending)
@@ -267,7 +267,7 @@ namespace RethinkDb
             });
         }
 
-        public static IOrderedSequenceQuery<T> OrderBy<T>(
+        public static OrderByQuery<T> OrderBy<T>(
             this ISequenceQuery<T> sequenceQuery,
             string indexName,
             OrderByDirection direction = OrderByDirection.Ascending)
@@ -278,7 +278,7 @@ namespace RethinkDb
             });
         }
 
-        public static IOrderedSequenceQuery<T> OrderBy<T, TIndexType>(
+        public static OrderByQuery<T> OrderBy<T, TIndexType>(
             this ISequenceQuery<T> sequenceQuery,
             IIndex<T, TIndexType> index,
             OrderByDirection direction = OrderByDirection.Ascending)
@@ -290,26 +290,26 @@ namespace RethinkDb
         }
 
         // LINQ-compatible alias for OrderBy
-        public static IOrderedSequenceQuery<T> OrderByDescending<T>(
+        public static OrderByQuery<T> OrderByDescending<T>(
             this ISequenceQuery<T> sequenceQuery,
             Expression<Func<T, object>> memberReferenceExpression)
         {
             return sequenceQuery.OrderBy(memberReferenceExpression, OrderByDirection.Descending);
         }
-        public static IOrderedSequenceQuery<T> OrderByDescending<T>(
+        public static OrderByQuery<T> OrderByDescending<T>(
             this ISequenceQuery<T> sequenceQuery,
             string indexName)
         {
             return sequenceQuery.OrderBy(indexName, OrderByDirection.Descending);
         }
-        public static IOrderedSequenceQuery<T> OrderByDescending<T, TIndexType>(
+        public static OrderByQuery<T> OrderByDescending<T, TIndexType>(
             this ISequenceQuery<T> sequenceQuery,
             IIndex<T, TIndexType> index)
         {
             return sequenceQuery.OrderBy(index, OrderByDirection.Descending);
         }
 
-        public static IOrderedSequenceQuery<T> ThenBy<T>(
+        public static OrderByQuery<T> ThenBy<T>(
             this IOrderedSequenceQuery<T> orderByQuery,
             Expression<Func<T, object>> memberReferenceExpression,
             OrderByDirection direction = OrderByDirection.Ascending)
@@ -326,65 +326,65 @@ namespace RethinkDb
         }
 
         // LINQ-compatible alias for OrderBy
-        public static IOrderedSequenceQuery<T> ThenByDescending<T>(
+        public static OrderByQuery<T> ThenByDescending<T>(
             this IOrderedSequenceQuery<T> orderByQuery,
             Expression<Func<T, object>> memberReferenceExpression)
         {
             return orderByQuery.ThenBy(memberReferenceExpression, OrderByDirection.Descending);
         }
 
-        public static ISequenceQuery<T> Skip<T>(this ISequenceQuery<T> sequenceQuery, int count)
+        public static SkipQuery<T> Skip<T>(this ISequenceQuery<T> sequenceQuery, int count)
         {
             return new SkipQuery<T>(sequenceQuery, count);
         }
 
-        public static ISequenceQuery<T> Limit<T>(this ISequenceQuery<T> sequenceQuery, int count)
+        public static LimitQuery<T> Limit<T>(this ISequenceQuery<T> sequenceQuery, int count)
         {
             return new LimitQuery<T>(sequenceQuery, count);
         }
 
         // LINQ compatible alias for Limit
-        public static ISequenceQuery<T> Take<T>(this ISequenceQuery<T> sequenceQuery, int count)
+        public static LimitQuery<T> Take<T>(this ISequenceQuery<T> sequenceQuery, int count)
         {
             return sequenceQuery.Limit(count);
         }
 
-        public static ISequenceQuery<T> Slice<T>(this ISequenceQuery<T> sequenceQuery, int startIndex, int? endIndex = null)
+        public static SliceQuery<T> Slice<T>(this ISequenceQuery<T> sequenceQuery, int startIndex, int? endIndex = null)
         {
             return new SliceQuery<T>(sequenceQuery, startIndex, endIndex);
         }
 
-        public static ISequenceQuery<Tuple<TLeft, TRight>> InnerJoin<TLeft, TRight>(this ISequenceQuery<TLeft> leftQuery, ISequenceQuery<TRight> rightQuery, Expression<Func<TLeft, TRight, bool>> joinPredicate)
+        public static InnerJoinQuery<TLeft, TRight, Tuple<TLeft, TRight>> InnerJoin<TLeft, TRight>(this ISequenceQuery<TLeft> leftQuery, ISequenceQuery<TRight> rightQuery, Expression<Func<TLeft, TRight, bool>> joinPredicate)
         {
             return new InnerJoinQuery<TLeft, TRight, Tuple<TLeft, TRight>>(leftQuery, rightQuery, joinPredicate);
         }
 
-        public static ISequenceQuery<TResult> InnerJoin<TLeft, TRight, TResult>(this ISequenceQuery<TLeft> leftQuery, ISequenceQuery<TRight> rightQuery, Expression<Func<TLeft, TRight, bool>> joinPredicate)
+        public static InnerJoinQuery<TLeft, TRight, TResult> InnerJoin<TLeft, TRight, TResult>(this ISequenceQuery<TLeft> leftQuery, ISequenceQuery<TRight> rightQuery, Expression<Func<TLeft, TRight, bool>> joinPredicate)
         {
             return new InnerJoinQuery<TLeft, TRight, TResult>(leftQuery, rightQuery, joinPredicate);
         }
 
-        public static ISequenceQuery<Tuple<TLeft, TRight>> OuterJoin<TLeft, TRight>(this ISequenceQuery<TLeft> leftQuery, ISequenceQuery<TRight> rightQuery, Expression<Func<TLeft, TRight, bool>> joinPredicate)
+        public static OuterJoinQuery<TLeft, TRight, Tuple<TLeft, TRight>> OuterJoin<TLeft, TRight>(this ISequenceQuery<TLeft> leftQuery, ISequenceQuery<TRight> rightQuery, Expression<Func<TLeft, TRight, bool>> joinPredicate)
         {
             return new OuterJoinQuery<TLeft, TRight, Tuple<TLeft, TRight>>(leftQuery, rightQuery, joinPredicate);
         }
 
-        public static ISequenceQuery<TResult> OuterJoin<TLeft, TRight, TResult>(this ISequenceQuery<TLeft> leftQuery, ISequenceQuery<TRight> rightQuery, Expression<Func<TLeft, TRight, bool>> joinPredicate)
+        public static OuterJoinQuery<TLeft, TRight, TResult> OuterJoin<TLeft, TRight, TResult>(this ISequenceQuery<TLeft> leftQuery, ISequenceQuery<TRight> rightQuery, Expression<Func<TLeft, TRight, bool>> joinPredicate)
         {
             return new OuterJoinQuery<TLeft, TRight, TResult>(leftQuery, rightQuery, joinPredicate);
         }
 
-        public static ISequenceQuery<TTarget> Zip<TLeft, TRight, TTarget>(this ISequenceQuery<Tuple<TLeft, TRight>> sequenceQuery)
+        public static ZipQuery<Tuple<TLeft, TRight>, TTarget> Zip<TLeft, TRight, TTarget>(this ISequenceQuery<Tuple<TLeft, TRight>> sequenceQuery)
         {
             return new ZipQuery<Tuple<TLeft, TRight>, TTarget>(sequenceQuery);
         }
 
-        public static ISequenceQuery<TTarget> Zip<TJoinedType, TTarget>(this ISequenceQuery<TJoinedType> sequenceQuery)
+        public static ZipQuery<TJoinedType, TTarget> Zip<TJoinedType, TTarget>(this ISequenceQuery<TJoinedType> sequenceQuery)
         {
             return new ZipQuery<TJoinedType, TTarget>(sequenceQuery);
         }
 
-        public static ISequenceQuery<Tuple<TLeft, TRight>> EqJoin<TLeft, TRight>(
+        public static EqJoinQuery<TLeft, TRight, Tuple<TLeft, TRight>> EqJoin<TLeft, TRight>(
             this ISequenceQuery<TLeft> leftQuery,
             Expression<Func<TLeft, object>> leftMemberReferenceExpression,
             ISequenceQuery<TRight> rightQuery,
@@ -393,7 +393,7 @@ namespace RethinkDb
             return new EqJoinQuery<TLeft, TRight, Tuple<TLeft, TRight>>(leftQuery, leftMemberReferenceExpression, rightQuery, indexName);
         }
 
-        public static ISequenceQuery<TResult> EqJoin<TLeft, TRight, TResult>(
+        public static EqJoinQuery<TLeft, TRight, TResult> EqJoin<TLeft, TRight, TResult>(
             this ISequenceQuery<TLeft> leftQuery,
             Expression<Func<TLeft, object>> leftMemberReferenceExpression,
             ISequenceQuery<TRight> rightQuery,
@@ -402,7 +402,7 @@ namespace RethinkDb
             return new EqJoinQuery<TLeft, TRight, TResult>(leftQuery, leftMemberReferenceExpression, rightQuery, indexName);
         }
 
-        public static ISequenceQuery<Tuple<TLeft, TRight>> EqJoin<TLeft, TRight, TIndexType>(
+        public static EqJoinQuery<TLeft, TRight, Tuple<TLeft, TRight>> EqJoin<TLeft, TRight, TIndexType>(
             this ISequenceQuery<TLeft> leftQuery,
             Expression<Func<TLeft, object>> leftMemberReferenceExpression,
             ISequenceQuery<TRight> rightQuery,
@@ -411,7 +411,7 @@ namespace RethinkDb
             return leftQuery.EqJoin(leftMemberReferenceExpression, rightQuery, index.Name);
         }
 
-        public static ISequenceQuery<TResult> EqJoin<TLeft, TRight, TResult, TIndexType>(
+        public static EqJoinQuery<TLeft, TRight, TResult> EqJoin<TLeft, TRight, TResult, TIndexType>(
             this ISequenceQuery<TLeft> leftQuery,
             Expression<Func<TLeft, object>> leftMemberReferenceExpression,
             ISequenceQuery<TRight> rightQuery,
@@ -420,60 +420,60 @@ namespace RethinkDb
             return leftQuery.EqJoin<TLeft, TRight, TResult>(leftMemberReferenceExpression, rightQuery, index.Name);
         }
 
-        public static ISingleObjectQuery<T> Reduce<T>(this ISequenceQuery<T> sequenceQuery, Expression<Func<T, T, T>> reduceFunction)
+        public static ReduceQuery<T> Reduce<T>(this ISequenceQuery<T> sequenceQuery, Expression<Func<T, T, T>> reduceFunction)
         {
             return new ReduceQuery<T>(sequenceQuery, reduceFunction);
         }
 
-        public static ISingleObjectQuery<T> Nth<T>(this ISequenceQuery<T> sequenceQuery, int index)
+        public static NthQuery<T> Nth<T>(this ISequenceQuery<T> sequenceQuery, int index)
         {
             return new NthQuery<T>(sequenceQuery, index);
         }
 
-        public static ISequenceQuery<T> Distinct<T>(this ISequenceQuery<T> sequenceQuery)
+        public static DistinctQuery<T> Distinct<T>(this ISequenceQuery<T> sequenceQuery)
         {
             return new DistinctQuery<T>(sequenceQuery);
         }
 
-        public static ISequenceQuery<TTarget> ConcatMap<TOriginal, TTarget>(this ISequenceQuery<TOriginal> sequenceQuery, Expression<Func<TOriginal, IEnumerable<TTarget>>> mapping)
+        public static ConcatMapQuery<TOriginal, TTarget> ConcatMap<TOriginal, TTarget>(this ISequenceQuery<TOriginal> sequenceQuery, Expression<Func<TOriginal, IEnumerable<TTarget>>> mapping)
         {
             return new ConcatMapQuery<TOriginal, TTarget>(sequenceQuery, mapping);
         }
 
-        public static ISequenceQuery<T> Union<T>(this ISequenceQuery<T> query1, ISequenceQuery<T> query2)
+        public static UnionQuery<T> Union<T>(this ISequenceQuery<T> query1, ISequenceQuery<T> query2)
         {
             return new UnionQuery<T>(query1, query2);
         }
 
         [Obsolete("Use DateTimeOffset.UtcNow instead")]
-        public static ISingleObjectQuery<DateTimeOffset> Now()
+        public static NowQuery<DateTimeOffset> Now()
         {
             return new NowQuery<DateTimeOffset>();
         }
 
-        public static ISingleObjectQuery<TResult> Now<TResult>()
+        public static NowQuery<TResult> Now<TResult>()
         {
             return new NowQuery<TResult>();
         }
 
-        public static ISequenceQuery<T> Sample<T>(this ISequenceQuery<T> target, int count)
+        public static SampleQuery<T> Sample<T>(this ISequenceQuery<T> target, int count)
         {
             return new SampleQuery<T>(target, count);
         }
 
-        public static ISequenceQuery<T> HasFields<T>(this ISequenceQuery<T> target, params Expression<Func<T, object>>[] fields)
+        public static HasFieldsSequenceQuery<T> HasFields<T>(this ISequenceQuery<T> target, params Expression<Func<T, object>>[] fields)
         {
             return new HasFieldsSequenceQuery<T>(target, fields);
         }
 
-        public static ISingleObjectQuery<bool> HasFields<T>(this ISingleObjectQuery<T> target, params Expression<Func<T, object>>[] fields)
+        public static HasFieldsSingleObjectQuery<T> HasFields<T>(this ISingleObjectQuery<T> target, params Expression<Func<T, object>>[] fields)
         {
             return new HasFieldsSingleObjectQuery<T>(target, fields);
         }
 
         #region Grouping and Aggregation
 
-        public static IGroupingQuery<TIndexType, TRecord[]> Group<TRecord, TIndexType>(
+        public static GroupByIndexQuery<TRecord, TIndexType> Group<TRecord, TIndexType>(
             // Can only use indexName on Group on a TABLE, not any arbitrary sequence
             this ITableQuery<TRecord> table,
             string indexName
@@ -482,7 +482,7 @@ namespace RethinkDb
             return new GroupByIndexQuery<TRecord, TIndexType>(table, indexName);
         }
 
-        public static IGroupingQuery<TIndexType, TRecord[]> Group<TRecord, TIndexType>(
+        public static GroupByIndexQuery<TRecord, TIndexType> Group<TRecord, TIndexType>(
             // Can only use indexName on Group on a TABLE, not any arbitrary sequence
             this ITableQuery<TRecord> table,
             IIndex<TRecord, TIndexType> index
@@ -491,7 +491,7 @@ namespace RethinkDb
             return table.Group<TRecord, TIndexType>(index.Name);
         }
 
-        public static IGroupingQuery<TKey, TRecord[]> Group<TRecord, TKey>(
+        public static GroupByFunctionQuery<TRecord, TKey> Group<TRecord, TKey>(
             this ISequenceQuery<TRecord> sequenceQuery,
             Expression<Func<TRecord, TKey>> key
             )
@@ -499,7 +499,7 @@ namespace RethinkDb
             return new GroupByFunctionQuery<TRecord, TKey>(sequenceQuery, key);
         }
 
-        public static IGroupingQuery<Tuple<TKey1, TKey2>, TRecord[]> Group<TRecord, TKey1, TKey2>(
+        public static GroupByFunctionQuery<TRecord, TKey1, TKey2, Tuple<TKey1, TKey2>> Group<TRecord, TKey1, TKey2>(
             this ISequenceQuery<TRecord> sequenceQuery,
             Expression<Func<TRecord, TKey1>> key1,
             Expression<Func<TRecord, TKey2>> key2
@@ -508,7 +508,7 @@ namespace RethinkDb
             return new GroupByFunctionQuery<TRecord, TKey1, TKey2, Tuple<TKey1, TKey2>>(sequenceQuery, key1, key2);
         }
 
-        public static IGroupingQuery<TGroupingKey, TRecord[]> Group<TRecord, TKey1, TKey2, TGroupingKey>(
+        public static GroupByFunctionQuery<TRecord, TKey1, TKey2, TGroupingKey> Group<TRecord, TKey1, TKey2, TGroupingKey>(
             this ISequenceQuery<TRecord> sequenceQuery,
             Expression<Func<TRecord, TKey1>> key1,
             Expression<Func<TRecord, TKey2>> key2
@@ -517,7 +517,7 @@ namespace RethinkDb
             return new GroupByFunctionQuery<TRecord, TKey1, TKey2, TGroupingKey>(sequenceQuery, key1, key2);
         }
 
-        public static IGroupingQuery<Tuple<TKey1, TKey2, TKey3>, TRecord[]> Group<TRecord, TKey1, TKey2, TKey3>(
+        public static GroupByFunctionQuery<TRecord, TKey1, TKey2, TKey3, Tuple<TKey1, TKey2, TKey3>> Group<TRecord, TKey1, TKey2, TKey3>(
             this ISequenceQuery<TRecord> sequenceQuery,
             Expression<Func<TRecord, TKey1>> key1,
             Expression<Func<TRecord, TKey2>> key2,
@@ -527,7 +527,7 @@ namespace RethinkDb
             return new GroupByFunctionQuery<TRecord, TKey1, TKey2, TKey3, Tuple<TKey1, TKey2, TKey3>>(sequenceQuery, key1, key2, key3);
         }
 
-        public static IGroupingQuery<TGroupingKey, TRecord[]> Group<TRecord, TKey1, TKey2, TKey3, TGroupingKey>(
+        public static GroupByFunctionQuery<TRecord, TKey1, TKey2, TKey3, TGroupingKey> Group<TRecord, TKey1, TKey2, TKey3, TGroupingKey>(
             this ISequenceQuery<TRecord> sequenceQuery,
             Expression<Func<TRecord, TKey1>> key1,
             Expression<Func<TRecord, TKey2>> key2,
@@ -537,31 +537,31 @@ namespace RethinkDb
             return new GroupByFunctionQuery<TRecord, TKey1, TKey2, TKey3, TGroupingKey>(sequenceQuery, key1, key2, key3);
         }
 
-        public static ISequenceQuery<UngroupObject<TKey, TValue>> Ungroup<TKey, TValue>(this IGroupingQuery<TKey, TValue> groupingQuery)
+        public static UngroupQuery<TKey, TValue, UngroupObject<TKey, TValue>> Ungroup<TKey, TValue>(this IGroupingQuery<TKey, TValue> groupingQuery)
         {
             return new UngroupQuery<TKey, TValue, UngroupObject<TKey, TValue>>(groupingQuery);
         }
 
-        public static ISequenceQuery<TResult> Ungroup<TKey, TValue, TResult>(this IGroupingQuery<TKey, TValue> groupingQuery)
+        public static UngroupQuery<TKey, TValue, TResult> Ungroup<TKey, TValue, TResult>(this IGroupingQuery<TKey, TValue> groupingQuery)
         {
             return new UngroupQuery<TKey, TValue, TResult>(groupingQuery);
         }
 
-        public static IGroupingQuery<TKey, TTarget[]> Map<TKey, TOriginal, TTarget>(
+        public static MapGroupQuery<TKey, TOriginal, TTarget> Map<TKey, TOriginal, TTarget>(
             this IGroupingQuery<TKey, TOriginal[]> groupingQuery,
             Expression<Func<TOriginal, TTarget>> mapExpression)
         {
             return new MapGroupQuery<TKey, TOriginal, TTarget>(groupingQuery, mapExpression);
         }
 
-        public static IGroupingQuery<TKey, TRecord> Reduce<TKey, TRecord>(
+        public static ReduceGroupQuery<TKey, TRecord> Reduce<TKey, TRecord>(
             this IGroupingQuery<TKey, TRecord[]> groupingQuery,
             Expression<Func<TRecord, TRecord, TRecord>> reduceFunction)
         {
             return new ReduceGroupQuery<TKey, TRecord>(groupingQuery, reduceFunction);
         }
 
-        public static IGroupingQuery<TKey, TRecord> Min<TKey, TRecord, TExpressionValue>(
+        public static MinGroupAggregateQuery<TKey, TRecord, TExpressionValue> Min<TKey, TRecord, TExpressionValue>(
             this IGroupingQuery<TKey, TRecord[]> groupingQuery,
             Expression<Func<TRecord, TExpressionValue>> field = null
             )
@@ -569,7 +569,7 @@ namespace RethinkDb
             return new MinGroupAggregateQuery<TKey, TRecord, TExpressionValue>(groupingQuery, field);
         }
 
-        public static ISingleObjectQuery<TRecord> Min<TRecord, TExpressionValue>(
+        public static MinAggregateQuery<TRecord, TExpressionValue> Min<TRecord, TExpressionValue>(
             this ISequenceQuery<TRecord> sequenceQuery,
             Expression<Func<TRecord, TExpressionValue>> field = null
             )
@@ -577,7 +577,7 @@ namespace RethinkDb
             return new MinAggregateQuery<TRecord, TExpressionValue>(sequenceQuery, field);
         }
 
-        public static IGroupingQuery<TKey, TRecord> Max<TKey, TRecord, TExpressionValue>(
+        public static MaxGroupAggregateQuery<TKey, TRecord, TExpressionValue> Max<TKey, TRecord, TExpressionValue>(
             this IGroupingQuery<TKey, TRecord[]> groupingQuery,
             Expression<Func<TRecord, TExpressionValue>> field = null
             )
@@ -585,7 +585,7 @@ namespace RethinkDb
             return new MaxGroupAggregateQuery<TKey, TRecord, TExpressionValue>(groupingQuery, field);
         }
 
-        public static ISingleObjectQuery<TRecord> Max<TRecord, TExpressionValue>(
+        public static MaxAggregateQuery<TRecord, TExpressionValue> Max<TRecord, TExpressionValue>(
             this ISequenceQuery<TRecord> sequenceQuery,
             Expression<Func<TRecord, TExpressionValue>> field = null
             )
@@ -593,7 +593,7 @@ namespace RethinkDb
             return new MaxAggregateQuery<TRecord, TExpressionValue>(sequenceQuery, field);
         }
 
-        public static IGroupingQuery<TKey, double> Avg<TKey, TRecord>(
+        public static AvgGroupAggregateQuery<TKey, TRecord, double> Avg<TKey, TRecord>(
             this IGroupingQuery<TKey, TRecord[]> groupingQuery,
             Expression<Func<TRecord, double>> field = null
             )
@@ -601,7 +601,7 @@ namespace RethinkDb
             return new AvgGroupAggregateQuery<TKey, TRecord, double>(groupingQuery, field);
         }
 
-        public static IGroupingQuery<TKey, TAvgType> Avg<TKey, TRecord, TAvgType>(
+        public static AvgGroupAggregateQuery<TKey, TRecord, TAvgType> Avg<TKey, TRecord, TAvgType>(
             this IGroupingQuery<TKey, TRecord[]> groupingQuery,
             Expression<Func<TRecord, TAvgType>> field = null
             )
@@ -609,7 +609,7 @@ namespace RethinkDb
             return new AvgGroupAggregateQuery<TKey, TRecord, TAvgType>(groupingQuery, field);
         }
 
-        public static ISingleObjectQuery<double> Avg<TRecord>(
+        public static AvgAggregateQuery<TRecord, double> Avg<TRecord>(
             this ISequenceQuery<TRecord> sequenceQuery,
             Expression<Func<TRecord, double>> field = null
             )
@@ -617,7 +617,7 @@ namespace RethinkDb
             return new AvgAggregateQuery<TRecord, double>(sequenceQuery, field);
         }
 
-        public static ISingleObjectQuery<TAvgType> Avg<TRecord, TAvgType>(
+        public static AvgAggregateQuery<TRecord, TAvgType> Avg<TRecord, TAvgType>(
             this ISequenceQuery<TRecord> sequenceQuery,
             Expression<Func<TRecord, TAvgType>> field = null
             )
@@ -625,7 +625,7 @@ namespace RethinkDb
             return new AvgAggregateQuery<TRecord, TAvgType>(sequenceQuery, field);
         }
 
-        public static IGroupingQuery<TKey, double> Sum<TKey, TRecord>(
+        public static SumGroupAggregateQuery<TKey, TRecord, double> Sum<TKey, TRecord>(
             this IGroupingQuery<TKey, TRecord[]> groupingQuery,
             Expression<Func<TRecord, double>> field = null
             )
@@ -633,7 +633,7 @@ namespace RethinkDb
             return new SumGroupAggregateQuery<TKey, TRecord, double>(groupingQuery, field);
         }
 
-        public static IGroupingQuery<TKey, TSumType> Sum<TKey, TRecord, TSumType>(
+        public static SumGroupAggregateQuery<TKey, TRecord, TSumType> Sum<TKey, TRecord, TSumType>(
             this IGroupingQuery<TKey, TRecord[]> groupingQuery,
             Expression<Func<TRecord, TSumType>> field = null
             )
@@ -641,7 +641,7 @@ namespace RethinkDb
             return new SumGroupAggregateQuery<TKey, TRecord, TSumType>(groupingQuery, field);
         }
 
-        public static ISingleObjectQuery<double> Sum<TRecord>(
+        public static SumAggregateQuery<TRecord, double> Sum<TRecord>(
             this ISequenceQuery<TRecord> sequenceQuery,
             Expression<Func<TRecord, double>> field = null
             )
@@ -649,7 +649,7 @@ namespace RethinkDb
             return new SumAggregateQuery<TRecord, double>(sequenceQuery, field);
         }
 
-        public static ISingleObjectQuery<TSumType> Sum<TRecord, TSumType>(
+        public static SumAggregateQuery<TRecord, TSumType> Sum<TRecord, TSumType>(
             this ISequenceQuery<TRecord> sequenceQuery,
             Expression<Func<TRecord, TSumType>> field = null
             )
@@ -657,7 +657,7 @@ namespace RethinkDb
             return new SumAggregateQuery<TRecord, TSumType>(sequenceQuery, field);
         }
 
-        public static IGroupingQuery<TKey, int> Count<TKey, TRecord>(
+        public static CountGroupAggregateQuery<TKey, TRecord> Count<TKey, TRecord>(
             this IGroupingQuery<TKey, TRecord[]> groupingQuery,
             Expression<Func<TRecord, bool>> predicate = null
             )
@@ -665,7 +665,7 @@ namespace RethinkDb
             return new CountGroupAggregateQuery<TKey, TRecord>(groupingQuery, predicate);
         }
 
-        public static ISingleObjectQuery<int> Count<T>(
+        public static CountAggregateQuery<T> Count<T>(
             this ISequenceQuery<T> target,
             Expression<Func<T, bool>> predicate = null
             )
@@ -673,7 +673,7 @@ namespace RethinkDb
             return new CountAggregateQuery<T>(target, predicate);
         }
 
-        public static IGroupingQuery<TKey, bool> Contains<TKey, TRecord>(
+        public static ContainsGroupAggregateQuery<TKey, TRecord>Contains<TKey, TRecord>(
             this IGroupingQuery<TKey, TRecord[]> groupingQuery,
             Expression<Func<TRecord, bool>> predicate = null
             )
@@ -681,7 +681,7 @@ namespace RethinkDb
             return new ContainsGroupAggregateQuery<TKey, TRecord>(groupingQuery, predicate);
         }
 
-        public static ISingleObjectQuery<bool> Contains<T>(
+        public static ContainsAggregateQuery<T> Contains<T>(
             this ISequenceQuery<T> target,
             Expression<Func<T, bool>> predicate = null
             )

--- a/rethinkdb-net/Query.cs
+++ b/rethinkdb-net/Query.cs
@@ -574,12 +574,44 @@ namespace RethinkDb
             return new MinGroupAggregateQuery<TKey, TRecord, TExpressionValue>(groupingQuery, field);
         }
 
+        public static MinAggregateIndexQuery<TRecord, TIndexType> Min<TRecord, TIndexType>(
+            this ITableQuery<TRecord> tableQuery,
+            string indexName
+        )
+        {
+            return new MinAggregateIndexQuery<TRecord, TIndexType>(tableQuery, indexName);
+        }
+
+        public static MinAggregateIndexQuery<TRecord, TIndexType> Min<TRecord, TIndexType>(
+            this ITableQuery<TRecord> tableQuery,
+            IIndex<TRecord, TIndexType> index
+        )
+        {
+            return new MinAggregateIndexQuery<TRecord, TIndexType>(tableQuery, index.Name);
+        }
+
         public static MinAggregateQuery<TRecord, TExpressionValue> Min<TRecord, TExpressionValue>(
             this ISequenceQuery<TRecord> sequenceQuery,
             Expression<Func<TRecord, TExpressionValue>> field = null
             )
         {
             return new MinAggregateQuery<TRecord, TExpressionValue>(sequenceQuery, field);
+        }
+
+        public static MaxAggregateIndexQuery<TRecord, TIndexType> Max<TRecord, TIndexType>(
+            this ITableQuery<TRecord> tableQuery,
+            string indexName
+        )
+        {
+            return new MaxAggregateIndexQuery<TRecord, TIndexType>(tableQuery, indexName);
+        }
+
+        public static MaxAggregateIndexQuery<TRecord, TIndexType> Max<TRecord, TIndexType>(
+            this ITableQuery<TRecord> tableQuery,
+            IIndex<TRecord, TIndexType> index
+        )
+        {
+            return new MaxAggregateIndexQuery<TRecord, TIndexType>(tableQuery, index.Name);
         }
 
         public static MaxGroupAggregateQuery<TKey, TRecord, TExpressionValue> Max<TKey, TRecord, TExpressionValue>(

--- a/rethinkdb-net/Query.cs
+++ b/rethinkdb-net/Query.cs
@@ -267,23 +267,23 @@ namespace RethinkDb
             });
         }
 
-        public static OrderByQuery<T> OrderBy<T>(
+        public static OrderByIndexQuery<T> OrderBy<T>(
             this ISequenceQuery<T> sequenceQuery,
             string indexName,
             OrderByDirection direction = OrderByDirection.Ascending)
         {
-            return new OrderByQuery<T>(sequenceQuery, new OrderByTerm<T> {
+            return new OrderByIndexQuery<T>(sequenceQuery, new OrderByTerm<T> {
                 Direction = direction,
                 IndexName = indexName,
             });
         }
 
-        public static OrderByQuery<T> OrderBy<T, TIndexType>(
+        public static OrderByIndexQuery<T> OrderBy<T, TIndexType>(
             this ISequenceQuery<T> sequenceQuery,
             IIndex<T, TIndexType> index,
             OrderByDirection direction = OrderByDirection.Ascending)
         {
-            return new OrderByQuery<T>(sequenceQuery, new OrderByTerm<T> {
+            return new OrderByIndexQuery<T>(sequenceQuery, new OrderByTerm<T> {
                 Direction = direction,
                 IndexName = index.Name,
             });
@@ -296,13 +296,13 @@ namespace RethinkDb
         {
             return sequenceQuery.OrderBy(memberReferenceExpression, OrderByDirection.Descending);
         }
-        public static OrderByQuery<T> OrderByDescending<T>(
+        public static OrderByIndexQuery<T> OrderByDescending<T>(
             this ISequenceQuery<T> sequenceQuery,
             string indexName)
         {
             return sequenceQuery.OrderBy(indexName, OrderByDirection.Descending);
         }
-        public static OrderByQuery<T> OrderByDescending<T, TIndexType>(
+        public static OrderByIndexQuery<T> OrderByDescending<T, TIndexType>(
             this ISequenceQuery<T> sequenceQuery,
             IIndex<T, TIndexType> index)
         {
@@ -336,6 +336,11 @@ namespace RethinkDb
         public static SkipQuery<T> Skip<T>(this ISequenceQuery<T> sequenceQuery, int count)
         {
             return new SkipQuery<T>(sequenceQuery, count);
+        }
+
+        public static LimitQueryChangefeedCompatible<T> Limit<T>(this IOrderByIndexQuery<T> orderByIndexQuery, int count)
+        {
+            return new LimitQueryChangefeedCompatible<T>(orderByIndexQuery, count);
         }
 
         public static LimitQuery<T> Limit<T>(this ISequenceQuery<T> sequenceQuery, int count)

--- a/rethinkdb-net/QueryTerm/BetweenQuery.cs
+++ b/rethinkdb-net/QueryTerm/BetweenQuery.cs
@@ -4,7 +4,7 @@ using RethinkDb.Spec;
 
 namespace RethinkDb.QueryTerm
 {
-    public class BetweenQuery<TSequence, TKey> : ISequenceQuery<TSequence>
+    public class BetweenQuery<TSequence, TKey> : ISequenceQuery<TSequence>, IChangefeedCompatibleQuery<TSequence>
     {
         private readonly ISequenceQuery<TSequence> tableTerm;
         private readonly TKey leftKey;

--- a/rethinkdb-net/QueryTerm/ChangesQuery.cs
+++ b/rethinkdb-net/QueryTerm/ChangesQuery.cs
@@ -1,16 +1,14 @@
 ﻿using RethinkDb.Spec;
-using System;
-using System.Linq.Expressions;
 
 namespace RethinkDb.QueryTerm
 {
     public class ChangesQuery<TRecord> : IStreamingSequenceQuery<DmlResponseChange<TRecord>>
     {
-        private readonly ISequenceQuery<TRecord> sequenceQuery;
+        private readonly IChangefeedCompatibleQuery<TRecord> changefeedCompatibleQuery;
 
-        public ChangesQuery(ISequenceQuery<TRecord> sequenceQuery)
+        public ChangesQuery(IChangefeedCompatibleQuery<TRecord> changefeedCompatibleQuery)
         {
-            this.sequenceQuery = sequenceQuery;
+            this.changefeedCompatibleQuery = changefeedCompatibleQuery;
         }
 
         public Term GenerateTerm(IQueryConverter queryConverter)
@@ -19,7 +17,7 @@ namespace RethinkDb.QueryTerm
             {
                 type = Term.TermType.CHANGES,
             };
-            term.args.Add(sequenceQuery.GenerateTerm(queryConverter));
+            term.args.Add(changefeedCompatibleQuery.GenerateTerm(queryConverter));
             return term;
         }
     }

--- a/rethinkdb-net/QueryTerm/FilterQuery.cs
+++ b/rethinkdb-net/QueryTerm/FilterQuery.cs
@@ -4,7 +4,7 @@ using System.Linq.Expressions;
 
 namespace RethinkDb.QueryTerm
 {
-    public class FilterQuery<T> : ISequenceQuery<T>
+    public class FilterQuery<T> : ISequenceQuery<T>, IChangefeedCompatibleQuery<T>
     {
         private readonly ISequenceQuery<T> sequenceQuery;
         private readonly Expression<Func<T, bool>> filterExpression;

--- a/rethinkdb-net/QueryTerm/GetQuery.cs
+++ b/rethinkdb-net/QueryTerm/GetQuery.cs
@@ -4,7 +4,7 @@ using System.Linq.Expressions;
 
 namespace RethinkDb.QueryTerm
 {
-    public class GetQuery<T> : IMutableSingleObjectQuery<T>
+    public class GetQuery<T> : IMutableSingleObjectQuery<T>, IChangefeedCompatibleQuery<T>
     {
         private readonly ISequenceQuery<T> tableTerm;
         private readonly string primaryKeyString;

--- a/rethinkdb-net/QueryTerm/LimitQueryChangefeedCompatible.cs
+++ b/rethinkdb-net/QueryTerm/LimitQueryChangefeedCompatible.cs
@@ -1,0 +1,14 @@
+﻿using RethinkDb.Spec;
+using System;
+using System.Linq.Expressions;
+
+namespace RethinkDb.QueryTerm
+{
+    public class LimitQueryChangefeedCompatible<T> : LimitQuery<T>, IChangefeedCompatibleQuery<T>
+    {
+        public LimitQueryChangefeedCompatible(IOrderByIndexQuery<T> sequenceQuery, int skipCount)
+            : base(sequenceQuery, skipCount)
+        {
+        }
+    }
+}

--- a/rethinkdb-net/QueryTerm/MapQuery.cs
+++ b/rethinkdb-net/QueryTerm/MapQuery.cs
@@ -4,7 +4,7 @@ using System.Linq.Expressions;
 
 namespace RethinkDb.QueryTerm
 {
-    public class MapQuery<TOriginal, TTarget> : ISequenceQuery<TTarget>
+    public class MapQuery<TOriginal, TTarget> : ISequenceQuery<TTarget>, IChangefeedCompatibleQuery<TTarget>
     {
         private readonly ISequenceQuery<TOriginal> sequenceQuery;
         private readonly Expression<Func<TOriginal, TTarget>> mapExpression;

--- a/rethinkdb-net/QueryTerm/MaxAggregateIndexQuery.cs
+++ b/rethinkdb-net/QueryTerm/MaxAggregateIndexQuery.cs
@@ -1,0 +1,43 @@
+﻿using RethinkDb.Spec;
+using System;
+using System.Linq.Expressions;
+
+namespace RethinkDb.QueryTerm
+{
+    public class MaxAggregateIndexQuery<TRecord, TIndexType> : ISingleObjectQuery<TRecord>, IChangefeedCompatibleQuery<TRecord>
+    {
+        private readonly ITableQuery<TRecord> tableQuery;
+        private readonly string indexName;
+
+        public MaxAggregateIndexQuery(ITableQuery<TRecord> tableQuery, string indexName)
+        {
+            this.tableQuery = tableQuery;
+            this.indexName = indexName;
+        }
+
+        public Term GenerateTerm(IQueryConverter queryConverter)
+        {
+            var term = new Term()
+            {
+                type = Term.TermType.MAX,
+            };
+            term.args.Add(tableQuery.GenerateTerm(queryConverter));
+            term.optargs.Add(
+                new Term.AssocPair()
+                {
+                    key = "index",
+                    val = new Term()
+                    {
+                        type = Term.TermType.DATUM,
+                        datum = new Datum()
+                        {
+                            type = Datum.DatumType.R_STR,
+                            r_str = indexName
+                        }
+                    }
+                }
+            );
+            return term;
+        }
+    }
+}

--- a/rethinkdb-net/QueryTerm/MinAggregateIndexQuery.cs
+++ b/rethinkdb-net/QueryTerm/MinAggregateIndexQuery.cs
@@ -1,0 +1,43 @@
+﻿using RethinkDb.Spec;
+using System;
+using System.Linq.Expressions;
+
+namespace RethinkDb.QueryTerm
+{
+    public class MinAggregateIndexQuery<TRecord, TIndexType> : ISingleObjectQuery<TRecord>, IChangefeedCompatibleQuery<TRecord>
+    {
+        private readonly ITableQuery<TRecord> tableQuery;
+        private readonly string indexName;
+
+        public MinAggregateIndexQuery(ITableQuery<TRecord> tableQuery, string indexName)
+        {
+            this.tableQuery = tableQuery;
+            this.indexName = indexName;
+        }
+
+        public Term GenerateTerm(IQueryConverter queryConverter)
+        {
+            var term = new Term()
+            {
+                type = Term.TermType.MIN,
+            };
+            term.args.Add(tableQuery.GenerateTerm(queryConverter));
+            term.optargs.Add(
+                new Term.AssocPair()
+                {
+                    key = "index",
+                    val = new Term()
+                    {
+                        type = Term.TermType.DATUM,
+                        datum = new Datum()
+                        {
+                            type = Datum.DatumType.R_STR,
+                            r_str = indexName
+                        }
+                    }
+                }
+            );
+            return term;
+        }
+    }
+}

--- a/rethinkdb-net/QueryTerm/OrderByIndexQuery.cs
+++ b/rethinkdb-net/QueryTerm/OrderByIndexQuery.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace RethinkDb.QueryTerm
+{
+    public class OrderByIndexQuery<T> : OrderByQuery<T>, IOrderByIndexQuery<T>
+    {
+        public OrderByIndexQuery(ISequenceQuery<T> sequenceQuery, params OrderByTerm<T>[] orderByMembers)
+            : base(sequenceQuery, orderByMembers)
+        {
+        }
+    }
+}

--- a/rethinkdb-net/QueryTerm/TableQuery.cs
+++ b/rethinkdb-net/QueryTerm/TableQuery.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace RethinkDb.QueryTerm
 {
-    public class TableQuery<T> : ITableQuery<T>
+    public class TableQuery<T> : ITableQuery<T>, IChangefeedCompatibleQuery<T>
     {
         private readonly IDatabaseQuery dbTerm;
         private readonly string table;

--- a/rethinkdb-net/QueryTerm/UnionQuery.cs
+++ b/rethinkdb-net/QueryTerm/UnionQuery.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace RethinkDb.QueryTerm
 {
-    public class UnionQuery<T> : ISequenceQuery<T>
+    public class UnionQuery<T> : ISequenceQuery<T>, IChangefeedCompatibleQuery<T>
     {
         private readonly ISequenceQuery<T> query1;
         private readonly ISequenceQuery<T> query2;

--- a/rethinkdb-net/rethinkdb-net.csproj
+++ b/rethinkdb-net/rethinkdb-net.csproj
@@ -225,6 +225,7 @@
     <Compile Include="Expressions\StringExpressionConverters.cs" />
     <Compile Include="MatchResponse.cs" />
     <Compile Include="MatchGroupResponse.cs" />
+    <Compile Include="Interfaces\IChangefeedCompatibleQuery.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/rethinkdb-net/rethinkdb-net.csproj
+++ b/rethinkdb-net/rethinkdb-net.csproj
@@ -229,6 +229,8 @@
     <Compile Include="QueryTerm\OrderByIndexQuery.cs" />
     <Compile Include="Interfaces\IOrderByIndexQuery.cs" />
     <Compile Include="QueryTerm\LimitQueryChangefeedCompatible.cs" />
+    <Compile Include="QueryTerm\MinAggregateIndexQuery.cs" />
+    <Compile Include="QueryTerm\MaxAggregateIndexQuery.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/rethinkdb-net/rethinkdb-net.csproj
+++ b/rethinkdb-net/rethinkdb-net.csproj
@@ -226,6 +226,9 @@
     <Compile Include="MatchResponse.cs" />
     <Compile Include="MatchGroupResponse.cs" />
     <Compile Include="Interfaces\IChangefeedCompatibleQuery.cs" />
+    <Compile Include="QueryTerm\OrderByIndexQuery.cs" />
+    <Compile Include="Interfaces\IOrderByIndexQuery.cs" />
+    <Compile Include="QueryTerm\LimitQueryChangefeedCompatible.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
* Support .Get().Changes()
* Support .OrderBy().Limit().Changes()
* Support .Union().Changes()
* Support .Min & .Max.Changes()

Also changes Query extension methods to return the concrete types they’re creating, which allows the IChangefeedCompatibleQuery interface to be available when it logically should be.