### PR TITLE
UpdateAndReturnChanges and DeleteAndReturnChanges overloads for sequences

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -16,6 +16,8 @@
 
 * Added changefeed support for min and max queries against an index.  [PR #210](https://github.com/mfenniak/rethinkdb-net/pull/210)
 
+* Added UpdateAndReturnChanges and DeleteAndReturnChanges overloads that take an ISequenceQuery to operate over multiple rows. [PR #212](https://github.com/mfenniak/rethinkdb-net/pull/212)
+
 ### Breaking Changes
 
 * Upgraded default RethinkDB protocol to version 0.4, which is only supported on RethinkDB 2.0 and above.  To use rethinkdb-net with an earlier version of RethinkDB, change the connection's Protocol property to ```RethinkDb.Protocols.Version_0_3_Json.Instance```.  [PR #211](https://github.com/mfenniak/rethinkdb-net/pull/211)

--- a/rethinkdb-net-test/Integration/SingleObjectTests.cs
+++ b/rethinkdb-net-test/Integration/SingleObjectTests.cs
@@ -116,6 +116,22 @@ namespace RethinkDb.Test.Integration
         }
 
         [Test]
+        public void UpdateAndReturnValueSequence()
+        {
+            var resp = connection.Run(testTable.UpdateAndReturnChanges(o => new TestObject() { Name = "Hello " + o.Id + "!" }));
+            Assert.That(resp, Is.Not.Null);
+            Assert.That(resp.FirstError, Is.Null);
+            Assert.That(resp.Replaced, Is.EqualTo(1));
+
+            Assert.That(resp.Changes, Is.Not.Null);
+            Assert.That(resp.Changes, Has.Length.EqualTo(1));
+            Assert.That(resp.Changes[0].NewValue, Is.Not.Null);
+            Assert.That(resp.Changes[0].OldValue, Is.Not.Null);
+            Assert.That(resp.Changes[0].OldValue.Name, Is.EqualTo("Jim Brown"));
+            Assert.That(resp.Changes[0].NewValue.Name, Is.EqualTo("Hello " + resp.Changes[0].OldValue.Id + "!"));
+        }
+
+        [Test]
         public void Delete()
         {
             DoDelete().Wait();
@@ -134,6 +150,21 @@ namespace RethinkDb.Test.Integration
         public void DeleteAndReturnValues()
         {
             var resp = connection.Run(testTable.Get(insertedObject.Id).DeleteAndReturnChanges());
+            Assert.That(resp, Is.Not.Null);
+            Assert.That(resp.FirstError, Is.Null);
+            Assert.That(resp.Deleted, Is.EqualTo(1));
+            Assert.That(resp.GeneratedKeys, Is.Null);
+            Assert.That(resp.Changes, Is.Not.Null);
+            Assert.That(resp.Changes, Has.Length.EqualTo(1));
+            Assert.That(resp.Changes[0].OldValue, Is.Not.Null);
+            Assert.That(resp.Changes[0].OldValue.Id, Is.EqualTo(insertedObject.Id));
+            Assert.That(resp.Changes[0].NewValue, Is.Null);
+        }
+
+        [Test]
+        public void DeleteAndReturnValuesSequence()
+        {
+            var resp = connection.Run(testTable.DeleteAndReturnChanges());
             Assert.That(resp, Is.Not.Null);
             Assert.That(resp.FirstError, Is.Null);
             Assert.That(resp.Deleted, Is.EqualTo(1));

--- a/rethinkdb-net-test/QueryTests/UpdateQueryTests.cs
+++ b/rethinkdb-net-test/QueryTests/UpdateQueryTests.cs
@@ -88,6 +88,30 @@ namespace RethinkDb.Test.QueryTests
             var nonAtomicArgs = term.optargs.Where(kv => kv.key == "non_atomic");
             Assert.That(nonAtomicArgs.Count(), Is.EqualTo(0));
         }
+
+        [Test]
+        public void UpdateAndReturnChanges()
+        {
+            var sequenceQuery = Substitute.For<ISequenceQuery<string>>();
+
+            var query = new UpdateAndReturnValueQuery<string>(
+                sequenceQuery,
+                s => "woot",
+                false);
+
+            var term = query.GenerateTerm(queryConverter);
+
+            var returnChangesArgs = term.optargs.Where(kv => kv.key == "return_changes");
+            Assert.That(returnChangesArgs.Count(), Is.EqualTo(1));
+
+            var returnChangesArg = returnChangesArgs.Single();
+
+            Assert.That(returnChangesArg.val, Is.Not.Null);
+            Assert.That(returnChangesArg.val.type, Is.EqualTo(Term.TermType.DATUM));
+            Assert.That(returnChangesArg.val.datum, Is.Not.Null);
+            Assert.That(returnChangesArg.val.datum.type, Is.EqualTo(Datum.DatumType.R_BOOL));
+            Assert.That(returnChangesArg.val.datum.r_bool, Is.True);
+        }
     }
 }
 

--- a/rethinkdb-net/Query.cs
+++ b/rethinkdb-net/Query.cs
@@ -190,6 +190,11 @@ namespace RethinkDb
             return new UpdateQuery<T>(target, updateExpression, nonAtomic);
         }
 
+        public static UpdateAndReturnValueQuery<T> UpdateAndReturnChanges<T>(this ISequenceQuery<T> target, Expression<Func<T, T>> updateExpression, bool nonAtomic = false)
+        {
+            return new UpdateAndReturnValueQuery<T>(target, updateExpression, nonAtomic);
+        }
+
         public static UpdateAndReturnValueQuery<T> UpdateAndReturnChanges<T>(this IMutableSingleObjectQuery<T> target, Expression<Func<T, T>> updateExpression, bool nonAtomic = false)
         {
             return new UpdateAndReturnValueQuery<T>(target, updateExpression, nonAtomic);
@@ -203,6 +208,11 @@ namespace RethinkDb
         public static DeleteQuery<T> Delete<T>(this IMutableSingleObjectQuery<T> target)
         {
             return new DeleteQuery<T>(target);
+        }
+
+        public static DeleteAndReturnValueQuery<T> DeleteAndReturnChanges<T>(this ISequenceQuery<T> target)
+        {
+            return new DeleteAndReturnValueQuery<T>(target);
         }
 
         public static DeleteAndReturnValueQuery<T> DeleteAndReturnChanges<T>(this IMutableSingleObjectQuery<T> target)

--- a/rethinkdb-net/QueryTerm/DeleteAndReturnValueQuery.cs
+++ b/rethinkdb-net/QueryTerm/DeleteAndReturnValueQuery.cs
@@ -14,9 +14,9 @@ namespace RethinkDb.QueryTerm
         {
         }
 
-        protected override void AddOptionalArguments(Term updateTerm)
+        protected override void AddOptionalArguments(Term deleteTerm)
         {
-            updateTerm.optargs.Add(new Term.AssocPair() {
+            deleteTerm.optargs.Add(new Term.AssocPair() {
                 key = "return_changes",
                 val = new Term() {
                     type = Term.TermType.DATUM,

--- a/rethinkdb-net/QueryTerm/DeleteAndReturnValueQuery.cs
+++ b/rethinkdb-net/QueryTerm/DeleteAndReturnValueQuery.cs
@@ -9,6 +9,11 @@ namespace RethinkDb.QueryTerm
         {
         }
 
+        public DeleteAndReturnValueQuery(ISequenceQuery<T> tableTerm)
+            : base(tableTerm)
+        {
+        }
+
         protected override void AddOptionalArguments(Term updateTerm)
         {
             updateTerm.optargs.Add(new Term.AssocPair() {

--- a/rethinkdb-net/QueryTerm/DeleteQueryBase.cs
+++ b/rethinkdb-net/QueryTerm/DeleteQueryBase.cs
@@ -31,7 +31,7 @@ namespace RethinkDb.QueryTerm
             return deleteTerm;
         }
 
-        protected virtual void AddOptionalArguments(Term updateTerm)
+        protected virtual void AddOptionalArguments(Term deleteTerm)
         {
         }
     }

--- a/rethinkdb-net/QueryTerm/UpdateAndReturnValueQuery.cs
+++ b/rethinkdb-net/QueryTerm/UpdateAndReturnValueQuery.cs
@@ -6,6 +6,11 @@ namespace RethinkDb.QueryTerm
 {
     public class UpdateAndReturnValueQuery<T> : UpdateQueryBase<T>, IWriteQuery<DmlResponse<T>>
     {
+        public UpdateAndReturnValueQuery(ISequenceQuery<T> tableTerm, Expression<Func<T, T>> updateExpression, bool nonAtomic)
+            : base(tableTerm, updateExpression, nonAtomic)
+        {
+        }
+
         public UpdateAndReturnValueQuery(IMutableSingleObjectQuery<T> singleObjectTerm, Expression<Func<T, T>> updateExpression, bool nonAtomic)
             : base(singleObjectTerm, updateExpression, nonAtomic)
         {


### PR DESCRIPTION
These two methods only took an `IMutableSingleObjectQuery<T>`, unlike their `Update()`/`Delete()` cousins.

I've added overloads that accept an `ISequenceQuery<T>`. I didn't implement this for `Replace` because most the time it doesn't make sense, unless maybe you use `.Limit(1)`, but then just use `.Nth(0)` and make sure the object exists first.

This obviously allows you to update/delete rows and get the objects back without querying the database again:
```
var u = conn.Run(Author.Table
    .Filter(r => r.TVShow == "House of Cards")
    .UpdateAndReturnChanges(r => new Author { Name = "Something Here" }));
```
