### PR TITLE
Change DmlResponse<T>.Changes to return an empty array

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,6 +22,8 @@
 
 * Upgraded default RethinkDB protocol to version 0.4, which is only supported on RethinkDB 2.0 and above.  To use rethinkdb-net with an earlier version of RethinkDB, change the connection's Protocol property to ```RethinkDb.Protocols.Version_0_3_Json.Instance```.  [PR #211](https://github.com/mfenniak/rethinkdb-net/pull/211)
 
+* Changed DmlResponse<T>.Changes to return an empty array rather than null if no changes were made. [PR #213](https://github.com/mfenniak/rethinkdb-net/pull/213)
+
 
 ## 0.10.0.0 (2015-04-14)
 

--- a/rethinkdb-net-test/Integration/SingleObjectTests.cs
+++ b/rethinkdb-net-test/Integration/SingleObjectTests.cs
@@ -177,6 +177,18 @@ namespace RethinkDb.Test.Integration
         }
 
         [Test]
+        public void DeleteAndReturnValuesSequenceNoChanges()
+        {
+            var resp = connection.Run(testTable.Filter(o => o.Name == "foo").DeleteAndReturnChanges());
+            Assert.That(resp, Is.Not.Null);
+            Assert.That(resp.FirstError, Is.Null);
+            Assert.That(resp.Deleted, Is.EqualTo(0));
+            Assert.That(resp.GeneratedKeys, Is.Null);
+            Assert.That(resp.Changes, Is.Not.Null);
+            Assert.That(resp.Changes, Has.Length.EqualTo(0));
+        }
+
+        [Test]
         public void GetUpdateNumericAdd()
         {
             DoGetUpdateNumeric(o => new TestObject() { SomeNumber = o.SomeNumber + 1 }, 1235).Wait();

--- a/rethinkdb-net/DmlResponse.cs
+++ b/rethinkdb-net/DmlResponse.cs
@@ -51,6 +51,11 @@ namespace RethinkDb
     [DataContract]
     public class DmlResponse<T> : DmlResponse
     {
+        public DmlResponse()
+        {
+            Changes = new DmlResponseChange<T>[0];
+        }
+
         [DataMember(Name = "changes")]
         public DmlResponseChange<T>[] Changes;
     }


### PR DESCRIPTION
As discussed in #212 fixing the Changes array so isn't null if no changes were made.

I've added this to the release notes under Breaking Changes since it is even though minor.