### PR TITLE
Support "Named Value Dictionaries"

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,6 +4,15 @@
 
 ### Features
 
+* Add support for free-form objects or fields in the form of ```Dictionary<string, object>```, or ```Dictionary<string, TValue>``` without the use of rethinkdb-net-newtonsoft, and including a bunch of dictionary-specific functionality. [PR #214](https://github.com/mfenniak/rethinkdb-net/pull/214)
+
+  * ContainsValue method can be used in expressions, particularly filtering and map expression.  eg. ```table.Filter(o => o.Properties.Contains("key"))```
+  * Keys and Values properties can be used to retrieve the keys and values of a dictionary as an array.
+  * Dictionary accessor can be used to access a key value, eg. ```table.Filter(o => o.Properties["key"] > 5)```
+  * New extension method ```SetValue``` on Dictionary can be used to add and update a value to a dictionary during an Update query, eg. ```table.Update(o => new User() { Properties = o.Properties.SetValue("new_key", "new_value") })``` will add or set the field "new_value" on the object "Properties".
+  * New extension method ```Without``` on Dictionary can be used to exclude a field from a table query.
+  * New automatic logic to determine the most appropriate native type to create when reading a ```Dictionary<string, object>``` from the server.
+
 * Supports RethinkDB's regular expression matching of strings, eg. ```table.Filter(o => o.Email != null && o.Email.Match(".*@(.*)") != null)```.  [Issue #107](https://github.com/mfenniak/rethinkdb-net/issues/107) & [PR #208](https://github.com/mfenniak/rethinkdb-net/pull/208)
 
 * Expressions can now reference member variables of server-side calculated data, eg. ```table.Filter(o => o.Email.Match(".*@(.*)").Groups[0].MatchedString == "google.com")``` would filter for all records with an e-mail address that has a domain of "google.com".  [PR #209](https://github.com/mfenniak/rethinkdb-net/pull/209)

--- a/rethinkdb-net-newtonsoft-test/Integration/CoreIntegrationTests.cs
+++ b/rethinkdb-net-newtonsoft-test/Integration/CoreIntegrationTests.cs
@@ -101,4 +101,13 @@ namespace RethinkDb.Newtonsoft.Test.Integration
             ConnectionFactory = ConfigurationAssembler.CreateConnectionFactory("testCluster");
         }
     }
+
+    [TestFixture]
+    public class NNamedValueDictionaryTests : NamedValueDictionaryTests
+    {
+        static NNamedValueDictionaryTests()
+        {
+            ConnectionFactory = ConfigurationAssembler.CreateConnectionFactory("testCluster");
+        }
+    }
 }

--- a/rethinkdb-net-newtonsoft-test/Integration/CoreIntegrationTests.cs
+++ b/rethinkdb-net-newtonsoft-test/Integration/CoreIntegrationTests.cs
@@ -1,4 +1,7 @@
-﻿using NUnit.Framework;
+﻿using System;
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
 using RethinkDb.Newtonsoft.Configuration;
 using RethinkDb.Test.Integration;
 
@@ -108,6 +111,22 @@ namespace RethinkDb.Newtonsoft.Test.Integration
         static NNamedValueDictionaryTests()
         {
             ConnectionFactory = ConfigurationAssembler.CreateConnectionFactory("testCluster");
+        }
+
+        protected override void MultipleItemSetterVerifyDictionary(TestObjectWithDictionary gil)
+        {
+            // FIXME: varies from the base class by:
+            //  - skill level being a double type, rather than an int
+            //  - updated at being a JObject, rather than a DateTimeOffset
+            // These are not the types I'd expect for these values, but, the RethinkDB datum converters are only plugged into the
+            // top level of the object with the newtonsoft converter, not the values inside a dictionary.  This is debatably wrong,
+            // but, I'm not fixing it right now... the best solution might be to incorporate any technical requirements of the
+            // newtonsoft extension library into the core, and drop this extension library...
+            gil.FreeformProperties.Should().Contain("best known for", "being awesome");
+            gil.FreeformProperties.Should().Contain("skill level", 1000.0);
+            gil.FreeformProperties.Should().ContainKey("updated at");
+            gil.FreeformProperties ["updated at"].Should().BeOfType<JObject>();
+            gil.FreeformProperties.Should().HaveCount(5);
         }
     }
 }

--- a/rethinkdb-net-newtonsoft/Configuration/NewtonSerializer.cs
+++ b/rethinkdb-net-newtonsoft/Configuration/NewtonSerializer.cs
@@ -10,6 +10,7 @@ namespace RethinkDb.Newtonsoft.Configuration
             AnonymousTypeDatumConverterFactory.Instance,
             BoundEnumDatumConverterFactory.Instance,
             NullableDatumConverterFactory.Instance,
+            NamedValueDictionaryDatumConverterFactory.Instance,
             NewtonsoftDatumConverterFactory.Instance
         )
         {

--- a/rethinkdb-net-test/DatumConverters/AbstractDatumConverterFactoryTests.cs
+++ b/rethinkdb-net-test/DatumConverters/AbstractDatumConverterFactoryTests.cs
@@ -2,12 +2,50 @@
 using NUnit.Framework;
 using NSubstitute;
 using RethinkDb.DatumConverters;
+using RethinkDb.Spec;
+using FluentAssertions;
+using System.Collections.Generic;
 
 namespace RethinkDb.Test.DatumConverters
 {
     [TestFixture]
     public class AbstractDatumConverterFactoryTests
     {
+        private static readonly Datum dateTimeOffsetDatum = new Datum()
+        {
+            type = Datum.DatumType.R_OBJECT,
+            r_object =
+            {
+                new Datum.AssocPair()
+                {
+                    key = "$reql_type$",
+                    val = new Datum()
+                    {
+                        type = Datum.DatumType.R_STR,
+                        r_str = "TIME"
+                    }
+                },
+                new Datum.AssocPair()
+                {
+                    key = "epoch_time",
+                    val = new Datum()
+                    {
+                        type = Datum.DatumType.R_NUM,
+                        r_num = 1414670462.5
+                    }
+                },
+                new Datum.AssocPair()
+                {
+                    key = "timezone",
+                    val = new Datum()
+                    {
+                        type = Datum.DatumType.R_STR,
+                        r_str = "-06:00"
+                    }
+                }
+            }
+        };
+
         public class TestDatumConverterFactory : AbstractDatumConverterFactory
         {
             public override bool TryGet<T>(IDatumConverterFactory rootDatumConverterFactory, out IDatumConverter<T> datumConverter)
@@ -51,6 +89,363 @@ namespace RethinkDb.Test.DatumConverters
             Assert.That(dcf.TryGet(typeof(string), dcf, out dc), Is.False);
             Assert.That(dc, Is.Null);
         }
+
+        [Test]
+        public void NativeTypeNull()
+        {
+            var dcf = new TestDatumConverterFactory();
+
+            var nativeType = dcf.GetBestNativeTypeForDatum(
+                                 new Datum() { type = Datum.DatumType.R_NULL });
+            nativeType.Should().NotBeNull();
+            nativeType.Should().Be(typeof(object));
+        }
+
+        [Test]
+        public void NativeTypeString()
+        {
+            var dcf = new TestDatumConverterFactory();
+
+            var nativeType = dcf.GetBestNativeTypeForDatum(
+                new Datum() { type = Datum.DatumType.R_STR, r_str = "Woot!" });
+            nativeType.Should().NotBeNull();
+            nativeType.Should().Be(typeof(string));
+        }
+
+        [Test]
+        public void NativeTypeInt()
+        {
+            var dcf = new TestDatumConverterFactory();
+
+            var nativeType = dcf.GetBestNativeTypeForDatum(
+                new Datum() { type = Datum.DatumType.R_NUM, r_num = 5000 });
+            nativeType.Should().NotBeNull();
+            nativeType.Should().Be(typeof(int));
+        }
+
+        [Test]
+        public void NativeTypeDouble()
+        {
+            var dcf = new TestDatumConverterFactory();
+
+            var nativeType = dcf.GetBestNativeTypeForDatum(
+                new Datum() { type = Datum.DatumType.R_NUM, r_num = 5.5 });
+            nativeType.Should().NotBeNull();
+            nativeType.Should().Be(typeof(double));
+        }
+
+        [Test]
+        public void NativeTypeBinary()
+        {
+            var dcf = new TestDatumConverterFactory();
+
+            var datum = new Datum() {
+                type = Datum.DatumType.R_OBJECT
+            };
+            datum.r_object.Add(new Datum.AssocPair() {
+                key = "$reql_type$",
+                val = new Datum() {
+                    type = Datum.DatumType.R_STR,
+                    r_str = "BINARY"
+                }
+            });
+            datum.r_object.Add(new Datum.AssocPair() {
+                key = "data",
+                val = new Datum() {
+                    type = Datum.DatumType.R_STR,
+                    r_str = "SGVsbG8sIHdvcmxkIQ=="
+                }
+            });
+            var nativeType = dcf.GetBestNativeTypeForDatum(datum);
+            nativeType.Should().NotBeNull();
+            nativeType.Should().Be(typeof(byte[]));
+        }
+
+        [Test]
+        public void NativeTypeDateTime()
+        {
+            var dcf = new TestDatumConverterFactory();
+
+            var nativeType = dcf.GetBestNativeTypeForDatum(dateTimeOffsetDatum);
+            nativeType.Should().NotBeNull();
+            nativeType.Should().Be(typeof(DateTimeOffset));
+        }
+
+        [Test]
+        public void NativeTypeNamedValueCollection()
+        {
+            var dcf = new TestDatumConverterFactory();
+            var datum = new Datum()
+            {
+                type = Datum.DatumType.R_OBJECT,
+                r_object =
+                {
+                    new Datum.AssocPair()
+                    {
+                        key = "key",
+                        val = new Datum()
+                        {
+                            type = Datum.DatumType.R_NUM,
+                            r_num = 100
+                        }
+                    }
+                }
+            };
+            var nativeType = dcf.GetBestNativeTypeForDatum(datum);
+            nativeType.Should().NotBeNull();
+            nativeType.Should().Be(typeof(Dictionary<string, object>));
+        }
+
+        [Test]
+        public void NativeTypeBool()
+        {
+            var dcf = new TestDatumConverterFactory();
+
+            var nativeType = dcf.GetBestNativeTypeForDatum(
+                new Datum() { type = Datum.DatumType.R_BOOL, r_bool = false });
+            nativeType.Should().NotBeNull();
+            nativeType.Should().Be(typeof(bool));
+        }
+
+        [Test]
+        public void NativeTypeStringArray()
+        {
+            var dcf = new TestDatumConverterFactory();
+
+            var nativeType = dcf.GetBestNativeTypeForDatum(
+                new Datum()
+                {
+                    type = Datum.DatumType.R_ARRAY,
+                    r_array =
+                    {
+                        new Datum { type = Datum.DatumType.R_STR, r_str = "Woot" },
+                        new Datum { type = Datum.DatumType.R_NULL },
+                    }
+                });
+
+            nativeType.Should().NotBeNull();
+            nativeType.Should().Be(typeof(string[]));
+        }
+
+        [Test]
+        public void NativeTypeBoolArray()
+        {
+            var dcf = new TestDatumConverterFactory();
+
+            var nativeType = dcf.GetBestNativeTypeForDatum(
+                new Datum()
+                {
+                    type = Datum.DatumType.R_ARRAY,
+                    r_array =
+                    {
+                        new Datum { type = Datum.DatumType.R_BOOL, r_bool = true },
+                        new Datum { type = Datum.DatumType.R_BOOL, r_bool = false },
+                    }
+                });
+
+            nativeType.Should().NotBeNull();
+            nativeType.Should().Be(typeof(bool[]));
+        }
+
+        [Test]
+        public void NativeTypeNullableBoolArray()
+        {
+            var dcf = new TestDatumConverterFactory();
+
+            var nativeType = dcf.GetBestNativeTypeForDatum(
+                new Datum()
+                {
+                    type = Datum.DatumType.R_ARRAY,
+                    r_array =
+                    {
+                        new Datum { type = Datum.DatumType.R_BOOL, r_bool = true },
+                        new Datum { type = Datum.DatumType.R_NULL },
+                        new Datum { type = Datum.DatumType.R_BOOL, r_bool = true },
+                    }
+                });
+
+            nativeType.Should().NotBeNull();
+            nativeType.Should().Be(typeof(bool?[]));
+        }
+
+        [Test]
+        public void NativeTypeIntArray()
+        {
+            var dcf = new TestDatumConverterFactory();
+
+            var nativeType = dcf.GetBestNativeTypeForDatum(new Datum()
+            {
+                type = Datum.DatumType.R_ARRAY,
+                r_array =
+                {
+                    new Datum { type = Datum.DatumType.R_NUM, r_num = 5 },
+                    new Datum { type = Datum.DatumType.R_NUM, r_num = 6 },
+                    new Datum { type = Datum.DatumType.R_NUM, r_num = 7 },
+                }
+            });
+
+            nativeType.Should().NotBeNull();
+            nativeType.Should().Be(typeof(int[]));
+        }
+
+        [Test]
+        public void NativeTypeNullableIntArray()
+        {
+            var dcf = new TestDatumConverterFactory();
+
+            var nativeType = dcf.GetBestNativeTypeForDatum(new Datum()
+            {
+                type = Datum.DatumType.R_ARRAY,
+                r_array =
+                {
+                    new Datum { type = Datum.DatumType.R_NUM, r_num = 5 },
+                    new Datum { type = Datum.DatumType.R_NULL },
+                    new Datum { type = Datum.DatumType.R_NUM, r_num = 7 },
+                }
+                });
+
+            nativeType.Should().NotBeNull();
+            nativeType.Should().Be(typeof(int?[]));
+        }
+
+        [Test]
+        public void NativeTypeDoubleArray()
+        {
+            var dcf = new TestDatumConverterFactory();
+
+            var nativeType = dcf.GetBestNativeTypeForDatum(new Datum()
+            {
+                type = Datum.DatumType.R_ARRAY,
+                r_array =
+                {
+                    new Datum { type = Datum.DatumType.R_NUM, r_num = 5.1 },
+                    new Datum { type = Datum.DatumType.R_NUM, r_num = 7.2 },
+                }
+                });
+
+            nativeType.Should().NotBeNull();
+            nativeType.Should().Be(typeof(double[]));
+        }
+
+        [Test]
+        public void NativeTypeNullableDoubleArray()
+        {
+            var dcf = new TestDatumConverterFactory();
+
+            var nativeType = dcf.GetBestNativeTypeForDatum(new Datum()
+            {
+                type = Datum.DatumType.R_ARRAY,
+                r_array =
+                {
+                    new Datum { type = Datum.DatumType.R_NUM, r_num = 5.1 },
+                    new Datum { type = Datum.DatumType.R_NULL },
+                    new Datum { type = Datum.DatumType.R_NUM, r_num = 7.2 },
+                }
+                });
+
+            nativeType.Should().NotBeNull();
+            nativeType.Should().Be(typeof(double?[]));
+        }
+
+        [Test]
+        public void NativeTypeDoubleAndIntArray()
+        {
+            var dcf = new TestDatumConverterFactory();
+
+            var nativeType = dcf.GetBestNativeTypeForDatum(new Datum()
+            {
+                type = Datum.DatumType.R_ARRAY,
+                r_array =
+                {
+                    new Datum { type = Datum.DatumType.R_NUM, r_num = 5.1 },
+                    new Datum { type = Datum.DatumType.R_NUM, r_num = 7 },
+                }
+                });
+
+            nativeType.Should().NotBeNull();
+            nativeType.Should().Be(typeof(double[]));
+        }
+
+        [Test]
+        public void NativeTypeNullableDoubleAndIntArray()
+        {
+            var dcf = new TestDatumConverterFactory();
+
+            var nativeType = dcf.GetBestNativeTypeForDatum(new Datum()
+            {
+                type = Datum.DatumType.R_ARRAY,
+                r_array =
+                {
+                    new Datum { type = Datum.DatumType.R_NUM, r_num = 5.1 },
+                    new Datum { type = Datum.DatumType.R_NULL },
+                    new Datum { type = Datum.DatumType.R_NUM, r_num = 7 },
+                }
+            });
+
+            nativeType.Should().NotBeNull();
+            nativeType.Should().Be(typeof(double?[]));
+        }
+
+        [Test]
+        public void NativeTypeDateTimeOffsetArray()
+        {
+            var dcf = new TestDatumConverterFactory();
+
+            var nativeType = dcf.GetBestNativeTypeForDatum(
+                new Datum()
+            {
+                type = Datum.DatumType.R_ARRAY,
+                r_array =
+                {
+                    dateTimeOffsetDatum,
+                    dateTimeOffsetDatum,
+                    dateTimeOffsetDatum
+                }
+            });
+
+            nativeType.Should().NotBeNull();
+            nativeType.Should().Be(typeof(DateTimeOffset[]));
+        }
+
+        [Test]
+        public void NativeTypeNullableDateTimeOffsetArray()
+        {
+            var dcf = new TestDatumConverterFactory();
+
+            var nativeType = dcf.GetBestNativeTypeForDatum(
+                new Datum()
+            {
+                type = Datum.DatumType.R_ARRAY,
+                r_array =
+                {
+                    dateTimeOffsetDatum,
+                    new Datum { type = Datum.DatumType.R_NULL },
+                    dateTimeOffsetDatum
+                }
+            });
+
+            nativeType.Should().NotBeNull();
+            nativeType.Should().Be(typeof(DateTimeOffset?[]));
+        }
+
+        [Test]
+        public void NativeTypeHeterogeneousTypeError()
+        {
+            var dcf = new TestDatumConverterFactory();
+
+            Action test = () => 
+                dcf.GetBestNativeTypeForDatum(
+                    new Datum()
+                {
+                    type = Datum.DatumType.R_ARRAY,
+                    r_array =
+                    {
+                        new Datum { type = Datum.DatumType.R_STR, r_str = "5" },
+                        new Datum { type = Datum.DatumType.R_NUM, r_num = 5 },
+                    }
+                });
+
+            test.ShouldThrow<RethinkDbException>().WithMessage("Heterogeneous arrays are not currently supported as their types are indistinguishable");
+        }
     }
 }
-

--- a/rethinkdb-net-test/DatumConverters/NamedValueDictionaryConverterTests.cs
+++ b/rethinkdb-net-test/DatumConverters/NamedValueDictionaryConverterTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using RethinkDb.Spec;
+using NSubstitute;
+using RethinkDb.DatumConverters;
+using FluentAssertions;
+
+namespace RethinkDb.Test.DatumConverters
+{
+    [TestFixture]
+    public class NamedValueDictionaryConverterTests
+    {
+        private IDatumConverterFactory datumConverterFactory;
+
+        [TestFixtureSetUp]
+        public void TestFixtureSetUp()
+        {
+            datumConverterFactory = Substitute.For<IDatumConverterFactory>();
+
+            var intDatumConverter = Substitute.For<IDatumConverter>();
+
+            IDatumConverter value;
+            datumConverterFactory
+                .TryGet(typeof(int), datumConverterFactory, out value)
+                .Returns(args =>
+                {
+                    args[2] = intDatumConverter;
+                    return true;
+                });
+        }
+
+        [Test]
+        public void ConvertDatumEmpty()
+        {
+            var datum = new Datum { type = Datum.DatumType.R_OBJECT };
+
+            var value = NamedValueDictionaryDatumConverterFactory.Instance.Get<Dictionary<string, object>>(datumConverterFactory).ConvertDatum(datum);
+
+            value.Should().NotBeNull();
+            value.Count.Should().Be(0);
+        }
+
+        [Test]
+        public void ConvertDictionaryEmpty()
+        {
+            var value = new Dictionary<string, object>();
+
+            var datum = NamedValueDictionaryDatumConverterFactory.Instance.Get<Dictionary<string, object>>(datumConverterFactory).ConvertObject(value);
+
+            datum.Should().NotBeNull();
+            datum.type.Should().Be(Datum.DatumType.R_OBJECT);
+            datum.r_object.Should().NotBeNull();
+            datum.r_object.Should().HaveCount(0);
+        }
+
+
+    }
+}

--- a/rethinkdb-net-test/Integration/DictionaryTests.cs
+++ b/rethinkdb-net-test/Integration/DictionaryTests.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using NUnit.Framework;
+using RethinkDb;
+using System.Linq;
+using System.Collections.Generic;
+using FluentAssertions;
+
+namespace RethinkDb.Test.Integration
+{
+    [TestFixture]
+    public class DictionaryTests : TestBase
+    {
+        private ITableQuery<TestObjectWithDictionary> testTable;
+
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+            connection.Run(Query.DbCreate("test"));
+            connection.Run(Query.Db("test").TableCreate("table"));
+            testTable = Query.Db("test").Table<TestObjectWithDictionary>("table");
+        }
+
+        [SetUp]
+        public virtual void SetUp()
+        {
+            connection.Run(
+                testTable.Insert(
+                    new[] {
+                        new TestObjectWithDictionary()
+                        {
+                            Name = "Jack Black",
+                            FreeformProperties = new Dictionary<string, object>()
+                            {
+                                { "Awesome-Level", 100 },
+                                { "Cool-Level", 15 },
+                                { "Best Movie", "School of Rock" }
+                            }
+                        },
+                        new TestObjectWithDictionary()
+                        {
+                            Name = "Gil Grissom",
+                            FreeformProperties = new Dictionary<string, object>()
+                            {
+                                { "Awesome-Level", 101 },
+                                { "Cool-Level", 0 },
+                                { "Best Known For", "CSI: Las Vegas" }
+                            }
+                        },
+                        new TestObjectWithDictionary()
+                        {
+                            Name = "Madame Curie",
+                            FreeformProperties = new Dictionary<string, object>()
+                            {
+                                { "Awesome-Level", 15 },
+                                { "Cool-Level", -1 },
+                                { "Impressive", true }
+                            }
+                        }
+                    }
+                )
+            );
+        }
+
+        [TearDown]
+        public virtual void TearDown()
+        {
+            connection.Run(testTable.Delete());
+        }
+
+        [Test]
+        public void ContainsKey()
+        {
+            var enumerable = connection.Run(testTable.Map(o => o.FreeformProperties.ContainsKey("Best Movie")));
+            var numTrue = enumerable.Count(r => r == true);
+            var numFalse = enumerable.Count(r => r == false);
+            numTrue.Should().Be(1);
+            numFalse.Should().Be(2);
+        }
+    }
+}

--- a/rethinkdb-net-test/Integration/NamedValueDictionaryTests.cs
+++ b/rethinkdb-net-test/Integration/NamedValueDictionaryTests.cs
@@ -151,5 +151,16 @@ namespace RethinkDb.Test.Integration
             gil.FreeformProperties ["updated at"].Should().BeOfType<DateTimeOffset>();
             gil.FreeformProperties.Should().HaveCount(5);
         }
+
+        [Test]
+        public void Without()
+        {
+            var dict = connection.Run(testTable
+                .Filter(o => o.Name == "Madame Curie")
+                .Map(o => o.FreeformProperties.Without("awesome level"))).Single();
+            dict.Should().ContainKey("cool level");
+            dict.Should().ContainKey("impressive");
+            dict.Should().HaveCount(2);
+        }
     }
 }

--- a/rethinkdb-net-test/Integration/NamedValueDictionaryTests.cs
+++ b/rethinkdb-net-test/Integration/NamedValueDictionaryTests.cs
@@ -162,5 +162,21 @@ namespace RethinkDb.Test.Integration
             dict.Should().ContainKey("impressive");
             dict.Should().HaveCount(2);
         }
+
+        [Test]
+        public void FilterByPropertyValue()
+        {
+            var impressivePeople = connection.Run(testTable.Filter(o => (bool)o.FreeformProperties["impressive"])).ToArray();
+            impressivePeople.Should().HaveCount(1);
+            impressivePeople [0].Name.Should().Be("Madame Curie");
+        }
+
+        [Test]
+        public void FilterByPropertyValueWithOperator()
+        {
+            var impressivePeople = connection.Run(testTable.Filter(o => (int)o.FreeformProperties["awesome level"] > 100)).ToArray();
+            impressivePeople.Should().HaveCount(1);
+            impressivePeople [0].Name.Should().Be("Gil Grissom");
+        }
     }
 }

--- a/rethinkdb-net-test/Integration/NamedValueDictionaryTests.cs
+++ b/rethinkdb-net-test/Integration/NamedValueDictionaryTests.cs
@@ -8,7 +8,7 @@ using FluentAssertions;
 namespace RethinkDb.Test.Integration
 {
     [TestFixture]
-    public class DictionaryTests : TestBase
+    public class NamedValueDictionaryTests : TestBase
     {
         private ITableQuery<TestObjectWithDictionary> testTable;
 
@@ -31,9 +31,9 @@ namespace RethinkDb.Test.Integration
                             Name = "Jack Black",
                             FreeformProperties = new Dictionary<string, object>()
                             {
-                                { "Awesome-Level", 100 },
-                                { "Cool-Level", 15 },
-                                { "Best Movie", "School of Rock" }
+                                { "awesome level", 100 },
+                                { "cool level", 15 },
+                                { "best movie", "School of Rock" }
                             }
                         },
                         new TestObjectWithDictionary()
@@ -41,9 +41,9 @@ namespace RethinkDb.Test.Integration
                             Name = "Gil Grissom",
                             FreeformProperties = new Dictionary<string, object>()
                             {
-                                { "Awesome-Level", 101 },
-                                { "Cool-Level", 0 },
-                                { "Best Known For", "CSI: Las Vegas" }
+                                { "awesome level", 101 },
+                                { "cool level", 0 },
+                                { "best known for", "CSI: Las Vegas" }
                             }
                         },
                         new TestObjectWithDictionary()
@@ -51,9 +51,9 @@ namespace RethinkDb.Test.Integration
                             Name = "Madame Curie",
                             FreeformProperties = new Dictionary<string, object>()
                             {
-                                { "Awesome-Level", 15 },
-                                { "Cool-Level", -1 },
-                                { "Impressive", true }
+                                { "awesome level", 15 },
+                                { "cool level", -1 },
+                                { "impressive", true }
                             }
                         }
                     }
@@ -70,7 +70,7 @@ namespace RethinkDb.Test.Integration
         [Test]
         public void ContainsKey()
         {
-            var enumerable = connection.Run(testTable.Map(o => o.FreeformProperties.ContainsKey("Best Movie")));
+            var enumerable = connection.Run(testTable.Map(o => o.FreeformProperties.ContainsKey("best movie")));
             var numTrue = enumerable.Count(r => r == true);
             var numFalse = enumerable.Count(r => r == false);
             numTrue.Should().Be(1);

--- a/rethinkdb-net-test/Integration/NamedValueDictionaryTests.cs
+++ b/rethinkdb-net-test/Integration/NamedValueDictionaryTests.cs
@@ -76,5 +76,15 @@ namespace RethinkDb.Test.Integration
             numTrue.Should().Be(1);
             numFalse.Should().Be(2);
         }
+
+        [Test]
+        public void Keys()
+        {
+            var keys = connection.Run(testTable.Filter(o => o.Name == "Madame Curie").Map(o => o.FreeformProperties.Keys)).Single();
+            keys.Should().Contain("awesome level");
+            keys.Should().Contain("cool level");
+            keys.Should().Contain("impressive");
+            keys.Should().HaveCount(3);
+        }
     }
 }

--- a/rethinkdb-net-test/Integration/NamedValueDictionaryTests.cs
+++ b/rethinkdb-net-test/Integration/NamedValueDictionaryTests.cs
@@ -96,5 +96,13 @@ namespace RethinkDb.Test.Integration
             values.Should().Contain(true);
             values.Should().HaveCount(3);
         }
+
+        [Test]
+        public void ItemGetter()
+        {
+            var gilGrissomBestKnownFor =
+                connection.Run(testTable.Filter(o => o.Name == "Gil Grissom").Map(o => o.FreeformProperties["best known for"])).Single();
+            gilGrissomBestKnownFor.Should().Be("CSI: Las Vegas");
+        }
     }
 }

--- a/rethinkdb-net-test/Integration/NamedValueDictionaryTests.cs
+++ b/rethinkdb-net-test/Integration/NamedValueDictionaryTests.cs
@@ -86,5 +86,15 @@ namespace RethinkDb.Test.Integration
             keys.Should().Contain("impressive");
             keys.Should().HaveCount(3);
         }
+
+        [Test]
+        public void Values()
+        {
+            var values = connection.Run(testTable.Filter(o => o.Name == "Madame Curie").Map(o => o.FreeformProperties.Values)).Single();
+            values.Should().Contain(15);
+            values.Should().Contain(-1);
+            values.Should().Contain(true);
+            values.Should().HaveCount(3);
+        }
     }
 }

--- a/rethinkdb-net-test/Integration/TestObjectWithDictionary.cs
+++ b/rethinkdb-net-test/Integration/TestObjectWithDictionary.cs
@@ -15,5 +15,12 @@ namespace RethinkDb.Test.Integration
 
         [DataMember(Name = "data")]
         public Dictionary<string, object> FreeformProperties;
+
+        [DataMember(Name = "valuetypedata")]
+        public Dictionary<string, int> IntegerProperties;
+
+        [DataMember(Name = "referencetypedata")]
+        public Dictionary<string, string> StringProperties;
+
     }
 }

--- a/rethinkdb-net-test/Integration/TestObjectWithDictionary.cs
+++ b/rethinkdb-net-test/Integration/TestObjectWithDictionary.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace RethinkDb.Test.Integration
+{
+    [DataContract]
+    public class TestObjectWithDictionary
+    {
+        [DataMember(Name = "id", EmitDefaultValue = false)]
+        public Guid Id;
+
+        [DataMember(Name = "name")]
+        public string Name;
+
+        [DataMember(Name = "data")]
+        public Dictionary<string, object> FreeformProperties;
+    }
+}

--- a/rethinkdb-net-test/rethinkdb-net-test.csproj
+++ b/rethinkdb-net-test/rethinkdb-net-test.csproj
@@ -123,6 +123,7 @@
     <Compile Include="Integration\RealtimePushTests.cs" />
     <Compile Include="Integration\TestObjectWithDictionary.cs" />
     <Compile Include="Integration\NamedValueDictionaryTests.cs" />
+    <Compile Include="DatumConverters\NamedValueDictionaryConverterTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/rethinkdb-net-test/rethinkdb-net-test.csproj
+++ b/rethinkdb-net-test/rethinkdb-net-test.csproj
@@ -121,8 +121,8 @@
     <Compile Include="DatumConverters\BinaryDatumConverterTests.cs" />
     <Compile Include="DatumConverters\DefaultDatumConverterTests.cs" />
     <Compile Include="Integration\RealtimePushTests.cs" />
-    <Compile Include="Integration\DictionaryTests.cs" />
     <Compile Include="Integration\TestObjectWithDictionary.cs" />
+    <Compile Include="Integration\NamedValueDictionaryTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/rethinkdb-net-test/rethinkdb-net-test.csproj
+++ b/rethinkdb-net-test/rethinkdb-net-test.csproj
@@ -121,6 +121,8 @@
     <Compile Include="DatumConverters\BinaryDatumConverterTests.cs" />
     <Compile Include="DatumConverters\DefaultDatumConverterTests.cs" />
     <Compile Include="Integration\RealtimePushTests.cs" />
+    <Compile Include="Integration\DictionaryTests.cs" />
+    <Compile Include="Integration\TestObjectWithDictionary.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/rethinkdb-net/Connection.cs
+++ b/rethinkdb-net/Connection.cs
@@ -43,7 +43,8 @@ namespace RethinkDb
                     ListDatumConverterFactory.Instance,
                     TimeSpanDatumConverterFactory.Instance,
                     GroupingDictionaryDatumConverterFactory.Instance,
-                    ObjectDatumConverterFactory.Instance
+                    ObjectDatumConverterFactory.Instance,
+                    NamedValueDictionaryDatumConverterFactory.Instance
                 ),
                 new Expressions.DefaultExpressionConverterFactory()
             );

--- a/rethinkdb-net/DatumConverters/AbstractDatumConverterFactory.cs
+++ b/rethinkdb-net/DatumConverters/AbstractDatumConverterFactory.cs
@@ -30,6 +30,26 @@ namespace RethinkDb.DatumConverters
                 return new Tuple<bool, IDatumConverter>(success, datumConverter);
             }
         }
+
+        public Type GetBestNativeTypeForDatum(Spec.Datum datum)
+        {
+            // Attempt to auto-detect the best native type for a given Datum.
+
+            switch (datum.type)
+            {
+                case Datum.DatumType.R_ARRAY:
+                case Datum.DatumType.R_BOOL:
+                case Datum.DatumType.R_JSON:
+                case Datum.DatumType.R_NULL:
+                case Datum.DatumType.R_NUM:
+                    throw new RethinkDbRuntimeException("I don't know what the best native type for this RethinkDB type is.");
+                case Datum.DatumType.R_OBJECT:
+                    return typeof(object);
+                case Datum.DatumType.R_STR:
+                    return typeof(string);
+                default:
+                    throw new RethinkDbInternalErrorException("Unrecognized datum type");
+            }
+        }
     }
 }
-

--- a/rethinkdb-net/DatumConverters/AbstractDatumConverterFactory.cs
+++ b/rethinkdb-net/DatumConverters/AbstractDatumConverterFactory.cs
@@ -1,6 +1,8 @@
 ﻿using System;
-using RethinkDb.Spec;
+using System.Collections.Generic;
 using System.Reflection;
+using System.Linq;
+using RethinkDb.Spec;
 
 namespace RethinkDb.DatumConverters
 {
@@ -38,15 +40,75 @@ namespace RethinkDb.DatumConverters
             switch (datum.type)
             {
                 case Datum.DatumType.R_ARRAY:
+                    {
+                        var hasNullValues = datum.r_array.Any(d => d.type == Datum.DatumType.R_NULL);
+
+                        var arrayValuesExcludingNulls = datum.r_array.Where(d => d.type != Datum.DatumType.R_NULL);
+
+                        var nativeTypesExcludingNulls = arrayValuesExcludingNulls.Select(GetBestNativeTypeForDatum).Distinct().ToArray();
+
+                        if (nativeTypesExcludingNulls.Length == 0)
+                            // only have nulls, or, empty
+                            return typeof(object[]);
+
+                        if (nativeTypesExcludingNulls.Length == 2 && nativeTypesExcludingNulls.Contains(typeof(double)) && nativeTypesExcludingNulls.Contains(typeof(int)))
+                            // we have numbers, both ints and doubles; we'll make an array of doubles as the return value.
+                            // This is a special case; only works because we know GetBestNativeTypeForDatum will only return int or double.  If that changes,
+                            // we need a more sophisticated manner to get the best numeric type here.
+                            nativeTypesExcludingNulls = new [] { typeof(double) };
+
+                        if (nativeTypesExcludingNulls.Length == 1)
+                        {
+                            Type arrayContentType = nativeTypesExcludingNulls[0];
+                            if (!hasNullValues || !arrayContentType.IsValueType)
+                                // we either have no nulls, or, this type can be assigned to null, so we just use the type
+                                return arrayContentType.MakeArrayType();
+                            else
+                                // the type is Nullable<T>[], where T is the type of all the objects in the array
+                                return typeof(Nullable<>).MakeGenericType(arrayContentType).MakeArrayType();
+                        }
+
+                        throw new RethinkDbRuntimeException("Heterogeneous arrays are not currently supported as their types are indistinguishable");
+                    }
+                
                 case Datum.DatumType.R_BOOL:
-                case Datum.DatumType.R_JSON:
+                    return typeof(bool);
+                
                 case Datum.DatumType.R_NULL:
-                case Datum.DatumType.R_NUM:
-                    throw new RethinkDbRuntimeException("I don't know what the best native type for this RethinkDB type is.");
-                case Datum.DatumType.R_OBJECT:
                     return typeof(object);
+                
+                case Datum.DatumType.R_NUM:
+                    if (datum.r_num == Math.Floor(datum.r_num))
+                        return typeof(int);
+                    else
+                        return typeof(double);
+                
+                case Datum.DatumType.R_OBJECT:
+                    {
+                        var reqlTypeDatum = datum.r_object.SingleOrDefault(kvp => kvp.key == "$reql_type$");
+                        if (reqlTypeDatum != null && reqlTypeDatum.val.type == Datum.DatumType.R_STR)
+                        {
+                            var reqlType = reqlTypeDatum.val.r_str;
+                            switch (reqlType)
+                            {
+                                case "BINARY":
+                                    return typeof(byte[]);
+                                case "TIME":
+                                    return typeof(DateTimeOffset);
+                                default:
+                                    throw new RethinkDbInternalErrorException("Unrecognized reql_type");
+                            }
+                        }
+
+                        return typeof(Dictionary<string, object>);
+                    }
+                
                 case Datum.DatumType.R_STR:
                     return typeof(string);
+                
+                case Datum.DatumType.R_JSON:
+                    throw new RethinkDbInternalErrorException("Unsupported datum type");
+
                 default:
                     throw new RethinkDbInternalErrorException("Unrecognized datum type");
             }

--- a/rethinkdb-net/DatumConverters/NamedValueDictionaryDatumConverterFactory.cs.cs
+++ b/rethinkdb-net/DatumConverters/NamedValueDictionaryDatumConverterFactory.cs.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace RethinkDb.DatumConverters
+{
+    public class NamedValueDictionaryDatumConverterFactory : AbstractDatumConverterFactory
+    {
+        public static readonly NamedValueDictionaryDatumConverterFactory Instance = new NamedValueDictionaryDatumConverterFactory();
+
+        private NamedValueDictionaryDatumConverterFactory()
+        {
+        }
+
+        public override bool TryGet<T>(IDatumConverterFactory rootDatumConverterFactory, out IDatumConverter<T> datumConverter)
+        {
+            datumConverter = null;
+            if (rootDatumConverterFactory == null)
+                throw new ArgumentNullException("rootDatumConverterFactory");
+
+            if (typeof(T) == typeof(Dictionary<string, object>))
+            {
+                datumConverter = (IDatumConverter<T>)new NamedValueDictionaryDatumConverter(rootDatumConverterFactory);
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    public class NamedValueDictionaryDatumConverter : AbstractReferenceTypeDatumConverter<Dictionary<string, object>>
+    {
+        private IDatumConverterFactory rootDatumConverterFactory;
+        private Dictionary<Type, IDatumConverter> datumConverterCache = new Dictionary<Type, IDatumConverter>();
+
+        public NamedValueDictionaryDatumConverter(IDatumConverterFactory rootDatumConverterFactory)
+        {
+            this.rootDatumConverterFactory = rootDatumConverterFactory;
+        }
+
+        #region IDatumConverter<T> Members
+
+        private IDatumConverter GetConverter(Type type)
+        {
+            IDatumConverter valueConverter = null;
+
+            if (datumConverterCache.TryGetValue(type, out valueConverter))
+                return valueConverter;
+
+            datumConverterCache[type] = valueConverter = rootDatumConverterFactory.Get(type);
+            return valueConverter;
+        }
+
+        public override Dictionary<string, object> ConvertDatum(Spec.Datum datum)
+        {
+            if (datum.type == Spec.Datum.DatumType.R_NULL)
+                return null;
+
+            if (datum.type != RethinkDb.Spec.Datum.DatumType.R_OBJECT)
+                throw new NotSupportedException("Attempted to convert Datum to named-value dictionary, but Datum was unsupported type " + datum.type);
+
+            Dictionary<string, object> retval = new Dictionary<string, object>();
+
+            foreach (var kvp in datum.r_object)
+            {
+                Type valueType = rootDatumConverterFactory.GetBestNativeTypeForDatum(kvp.val);
+                var valueConverter = GetConverter(valueType);
+                retval [kvp.key] = valueConverter.ConvertDatum(kvp.val);
+            }
+
+            return retval;
+        }
+
+        public override Spec.Datum ConvertObject(Dictionary<string, object> dictionary)
+        {
+            if (dictionary == null)
+                return new Spec.Datum() { type = Spec.Datum.DatumType.R_NULL };
+
+            var retval = new Spec.Datum() { type = Spec.Datum.DatumType.R_OBJECT };
+
+            foreach (var kvp in dictionary)
+            {
+                var valueConverter = GetConverter(kvp.Value.GetType());
+                var convertedValue = valueConverter.ConvertObject(kvp.Value);
+                retval.r_object.Add(new RethinkDb.Spec.Datum.AssocPair()
+                {
+                    key = kvp.Key,
+                    val = convertedValue,
+                });
+            }
+
+            return retval;
+        }
+
+        #endregion
+    }
+}

--- a/rethinkdb-net/Expressions/BaseExpression.cs
+++ b/rethinkdb-net/Expressions/BaseExpression.cs
@@ -189,6 +189,14 @@ namespace RethinkDb.Expressions
                     };
                 }
 
+                case ExpressionType.Convert:
+                {
+                    // The use-case for this right now is automatic boxing that occurs when setting a Dictionary<string,object>'s value
+                    // to a primitive.  In that particular case, we don't actually need to generate any ReQL for the conversion, so we're
+                    // just ignoring the Convert and mapping the expression inside.  Might need other behavior here in the future...
+                    return RecursiveMap(((UnaryExpression)expr).Operand);
+                }
+
                 default:
                 {
                     return AttemptClientSideConversion(datumConverterFactory, expr);

--- a/rethinkdb-net/Expressions/DefaultExpressionConverterFactory.cs
+++ b/rethinkdb-net/Expressions/DefaultExpressionConverterFactory.cs
@@ -30,6 +30,7 @@ namespace RethinkDb.Expressions
             DateTimeExpressionConverters.RegisterOnConverterFactory(this);
             GuidExpressionConverters.RegisterOnConverterFactory(this);
             StringExpressionConverters.RegisterOnConverterFactory(this);
+            DictionaryExpressionConverters.RegisterOnConverterFactory(this);
         }
 
         public void Reset()

--- a/rethinkdb-net/Expressions/DictionaryExpressionConverters.cs
+++ b/rethinkdb-net/Expressions/DictionaryExpressionConverters.cs
@@ -12,6 +12,10 @@ namespace RethinkDb.Expressions
             expressionConverterFactory.RegisterTemplateMapping<Dictionary<string, object>, string, bool>(
                 (d, k) => d.ContainsKey(k),
                 (d, k) => new Term() { type = Term.TermType.HAS_FIELDS, args = { d, k } });
+
+            expressionConverterFactory.RegisterTemplateMapping<Dictionary<string, object>, Dictionary<string, object>.KeyCollection>(
+                (d) => d.Keys,
+                (d) => new Term() { type = Term.TermType.KEYS, args = { d } });
         }
     }
 }

--- a/rethinkdb-net/Expressions/DictionaryExpressionConverters.cs
+++ b/rethinkdb-net/Expressions/DictionaryExpressionConverters.cs
@@ -34,6 +34,14 @@ namespace RethinkDb.Expressions
             expressionConverterFactory.RegisterTemplateMapping<Dictionary<string, object>, Dictionary<string, object>.ValueCollection>(
                 (d) => d.Values,
                 (d) => d);
+            
+            expressionConverterFactory.RegisterTemplateMapping<Dictionary<string, object>, string, Dictionary<string, object>>(
+                (d, k) => d.Without(k),
+                (d, k) => new Term()
+                {
+                    type = Term.TermType.WITHOUT,
+                    args = { d, k }
+                });
         }
     }
 }

--- a/rethinkdb-net/Expressions/DictionaryExpressionConverters.cs
+++ b/rethinkdb-net/Expressions/DictionaryExpressionConverters.cs
@@ -16,6 +16,12 @@ namespace RethinkDb.Expressions
             expressionConverterFactory.RegisterTemplateMapping<Dictionary<string, object>, Dictionary<string, object>.KeyCollection>(
                 (d) => d.Keys,
                 (d) => new Term() { type = Term.TermType.KEYS, args = { d } });
+
+            // There's no RethinkDB command to get the "values" of an object; so, return the actual dictionary when
+            // accessing .Values and assume the datum converter will do the right thing for this type.
+            expressionConverterFactory.RegisterTemplateMapping<Dictionary<string, object>, Dictionary<string, object>.ValueCollection>(
+                (d) => d.Values,
+                (d) => d);
         }
     }
 }

--- a/rethinkdb-net/Expressions/DictionaryExpressionConverters.cs
+++ b/rethinkdb-net/Expressions/DictionaryExpressionConverters.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using RethinkDb.Spec;
+
+namespace RethinkDb.Expressions
+{
+    public static class DictionaryExpressionConverters
+    {
+        public static void RegisterOnConverterFactory(DefaultExpressionConverterFactory expressionConverterFactory)
+        {
+            expressionConverterFactory.RegisterTemplateMapping<Dictionary<string, object>, string, bool>(
+                (d, k) => d.ContainsKey(k),
+                (d, k) => new Term() { type = Term.TermType.HAS_FIELDS, args = { d, k } });
+        }
+    }
+}

--- a/rethinkdb-net/Expressions/DictionaryExpressionConverters.cs
+++ b/rethinkdb-net/Expressions/DictionaryExpressionConverters.cs
@@ -13,6 +13,10 @@ namespace RethinkDb.Expressions
                 (d, k) => d.ContainsKey(k),
                 (d, k) => new Term() { type = Term.TermType.HAS_FIELDS, args = { d, k } });
 
+            expressionConverterFactory.RegisterTemplateMapping<Dictionary<string, object>, string, object>(
+                (d, k) => d[k],
+                (d, k) => new Term() { type = Term.TermType.GET_FIELD, args = { d, k } });
+
             expressionConverterFactory.RegisterTemplateMapping<Dictionary<string, object>, Dictionary<string, object>.KeyCollection>(
                 (d) => d.Keys,
                 (d) => new Term() { type = Term.TermType.KEYS, args = { d } });

--- a/rethinkdb-net/Expressions/DictionaryExpressionConverters.cs
+++ b/rethinkdb-net/Expressions/DictionaryExpressionConverters.cs
@@ -17,6 +17,14 @@ namespace RethinkDb.Expressions
                 (d, k) => d[k],
                 (d, k) => new Term() { type = Term.TermType.GET_FIELD, args = { d, k } });
 
+            expressionConverterFactory.RegisterTemplateMapping<Dictionary<string, object>, string, object, Dictionary<string, object>>(
+                (d, k, v) => d.SetValue(k, v),
+                (d, k, v) => new Term()
+                {
+                    type = Term.TermType.MERGE,
+                    args = { d, new Term() { type = Term.TermType.OBJECT, args = { k, v } } }
+                });
+
             expressionConverterFactory.RegisterTemplateMapping<Dictionary<string, object>, Dictionary<string, object>.KeyCollection>(
                 (d) => d.Keys,
                 (d) => new Term() { type = Term.TermType.KEYS, args = { d } });

--- a/rethinkdb-net/Interfaces/IDatumConverterFactory.cs
+++ b/rethinkdb-net/Interfaces/IDatumConverterFactory.cs
@@ -6,5 +6,6 @@ namespace RethinkDb
     {
         bool TryGet(Type datumType, IDatumConverterFactory rootDatumConverterFactory, out IDatumConverter datumConverter);
         bool TryGet<T>(IDatumConverterFactory rootDatumConverterFactory, out IDatumConverter<T> datumConverter);
+        Type GetBestNativeTypeForDatum(Spec.Datum datum);
     }
 }

--- a/rethinkdb-net/QueryConverter.cs
+++ b/rethinkdb-net/QueryConverter.cs
@@ -43,6 +43,11 @@ namespace RethinkDb
             return delegatedDatumConverterFactory.TryGet<T>(rootDatumConverterFactory, out datumConverter);
         }
 
+        public Type GetBestNativeTypeForDatum(Spec.Datum datum)
+        {
+            return delegatedDatumConverterFactory.GetBestNativeTypeForDatum(datum);
+        }
+
         #endregion
     }
 }

--- a/rethinkdb-net/ReQLExpression.cs
+++ b/rethinkdb-net/ReQLExpression.cs
@@ -39,5 +39,10 @@ namespace RethinkDb
         {
             throw new NotSupportedException("This method cannot be invoked directly, it can only be used as part of an expression tree.");
         }
+
+        public static Dictionary<TKey, TValue> Without<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key)
+        {
+            throw new NotSupportedException("This method cannot be invoked directly, it can only be used as part of an expression tree.");
+        }
     }
 }

--- a/rethinkdb-net/ReQLExpression.cs
+++ b/rethinkdb-net/ReQLExpression.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace RethinkDb
 {
@@ -30,6 +31,11 @@ namespace RethinkDb
         }
 
         public static MatchResponse Match(this string @string, string regexp)
+        {
+            throw new NotSupportedException("This method cannot be invoked directly, it can only be used as part of an expression tree.");
+        }
+
+        public static Dictionary<TKey, TValue> SetValue<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue value)
         {
             throw new NotSupportedException("This method cannot be invoked directly, it can only be used as part of an expression tree.");
         }

--- a/rethinkdb-net/rethinkdb-net.csproj
+++ b/rethinkdb-net/rethinkdb-net.csproj
@@ -233,6 +233,8 @@
     <Compile Include="QueryTerm\MaxAggregateIndexQuery.cs" />
     <Compile Include="Protocols\Version_0_4_JsonProtocol.cs" />
     <Compile Include="Protocols\Version_0_4_ProtobufProtocol.cs" />
+    <Compile Include="DatumConverters\NamedValueDictionaryDatumConverterFactory.cs.cs" />
+    <Compile Include="Expressions\DictionaryExpressionConverters.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
The long overdue capability to support free-form data objects inside rethinkdb-net without relying on the rethinkdb-net-newtonsoft add-on library.  This will also add many dictionary operations to the key capabilities.

- [x] Support converting ```Dictionary&lt;string,object>``` round-trip to RethinkDB.
- [x] Automatically detect the best object type to deserialize for a given RethinkDB value.
  - [x] numbers -> double or int
  - [x] objects:
    - [x] special case: byte array
    - [x] special case: DateTimeOffset
    - [x] named value collection
  - [x] string
  - [x] bool
  - [x] arrays.... 
    - [x] string arrays -- all types are string or null gets a string[]
    - [x] number arrays -- all types are int gets in int[], all types are int or null gets an int?[], all types are int or double gets a double[], all types are int or double or null gets a double?[]
    - [x] all types are the same and or null, and the type is a reference type, gets a TReferenceType[]
    - [x] all types are the same and or null, and the type is a value type, gets a TValueType?[]
    - [x] throw an error; unable to find a homogenous array type.  In the future, maybe we'd support a heterogeneous type like object[]
- [x] Dictionary operations:
  - [x] ```.ContainsKey(...)```
  - [x] ~~```.ContainsValue(...)```~~ No ReQL operation for this (and, why would you want to anyway?)
  - [x] ~~```Count``` property~~ No ReQL operation to find the number of keys in an object.
  - [x] ```Keys``` property
  - [x] ```Values``` property
  - [x] Item accessors; eg. ```dictionary[key]```, for getting.
  - [x] ~~Item accessors; eg. ```dictionary[key]```, for setting.~~  Doesn't return a Dictionary type, so can't make it work in a LINQ expression.  Created an alternative instead (next point).
  - [x] Extension method to set a dictionary value in an Update query; ```dict.SetValue(key, value).SetValue(key2, value2)```
  - [x] ~~```.Add(...)``` method~~  Returns void, can't use; however, SetValue extension method above does same functional capability.
  - [x] ~~```.Remove(...)``` method~~ No exact match for this in ReQL, but, did implement ```.Without()``` to exclude a key from a dictionary.
- [x] Do useful things with the values of a dictionary; since they're of type object, this might require supporting casts in the expression converter.  eg. ```.Filter(o => (int)o.FreeformProperties["awesome level"] > 10)```
- [x] Update release notes.
- [x] How hard would it be to support dictionaries other than &lt;string,object> now that most of the above work is done?  --> easy; this has been implemented.  Dictionary values can now be strongly typed or weakly typed by using System.Object.