### PR TITLE
Experimental prototype of dynamic object support

### DIFF
--- a/rethinkdb-net-test/Integration/DynamicTestObject.cs
+++ b/rethinkdb-net-test/Integration/DynamicTestObject.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace RethinkDb.Test.Integration
+{
+    [DataContract]
+    public class DynamicTestObject
+    {
+        [DataMember(Name = "id", EmitDefaultValue = false)]
+        public Guid Id;
+
+        [DataMember(Name = "d1")]
+        public dynamic d1;
+
+        [DataMember(Name = "d2")]
+        public dynamic d2 { get; set; }
+
+        [DataMember(Name = "d3")]
+        public dynamic d3;
+
+        [DataMember(Name = "d4")]
+        public dynamic d4 { get; set; }
+    }
+}

--- a/rethinkdb-net-test/Integration/DynamicTests.cs
+++ b/rethinkdb-net-test/Integration/DynamicTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using NUnit.Framework;
+using FluentAssertions;
+
+namespace RethinkDb.Test.Integration
+{
+    [TestFixture]
+    public class DynamicTests : TestBase
+    {
+        private ITableQuery<dynamic> testTable;
+
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+            connection.Run(Query.DbCreate("test"));
+            connection.Run(Query.Db("test").TableCreate("table"));
+            testTable = Query.Db("test").Table<dynamic>("table");
+        }
+
+        [SetUp]
+        public virtual void SetUp()
+        {
+            /*
+            connection.RunAsync(testTable.Insert(new List<TestObject> {
+                new TestObject() { Id = "1", Name = "1", SomeNumber = 1, Tags = new[] { "odd" }, Children = new TestObject[] { new TestObject { Name = "C1" } }, ChildrenList = new List<TestObject> { new TestObject() { Name = "C1" } }, ChildrenIList = new List<TestObject> { new TestObject() { Name = "C1" } } },
+                new TestObject() { Id = "2", Name = "2", SomeNumber = 2, Tags = new[] { "even" }, Children = new TestObject[0], ChildrenList = new List<TestObject> { }, ChildrenIList = new List<TestObject> { } },
+                new TestObject() { Id = "3", Name = "3", SomeNumber = 3, Tags = new[] { "odd" }, Children = new TestObject[] { new TestObject { Name = "C3" } }, ChildrenList = new List<TestObject> { new TestObject() { Name = "C3" } }, ChildrenIList = new List<TestObject> { new TestObject() { Name = "C3" } } },
+                new TestObject() { Id = "4", Name = "4", SomeNumber = 4, Tags = new[] { "even" }, Children = new TestObject[0], ChildrenList = new List<TestObject> { }, ChildrenIList = new List<TestObject> { } },
+                new TestObject() { Id = "5", Name = "5", SomeNumber = 5, Tags = new[] { "odd" }, Children = new TestObject[] { new TestObject { Name = "C5" } }, ChildrenList = new List<TestObject> { new TestObject() { Name = "C5" } }, ChildrenIList = new List<TestObject> { new TestObject() { Name = "C5" } } },
+                new TestObject() { Id = "6", Name = "6", SomeNumber = 6, Tags = new[] { "even" }, Children = new TestObject[0], ChildrenList = new List<TestObject> { }, ChildrenIList = new List<TestObject> { } },
+                new TestObject() { Id = "7", Name = "7", SomeNumber = 7, Tags = new[] { "odd" }, Children = new TestObject[] { new TestObject { Name = "C7" } }, ChildrenList = new List<TestObject> { new TestObject() { Name = "C7" } }, ChildrenIList = new List<TestObject> { new TestObject() { Name = "C7" } } },
+            })).Wait();
+            */
+        }
+
+        [TearDown]
+        public virtual void TearDown()
+        {
+            connection.Run(testTable.Delete());
+        }
+
+        [Test]
+        public void Test()
+        {
+            connection.Run(testTable.Insert(new { name = "Mathieu" }));
+
+            int rowCount = 0;
+            foreach (var obj in connection.Run(testTable))
+            {
+                // Should be able to access the property "name" just like we would have with the anonymous type.
+                string name = obj.name;
+                name.Should().Be("Mathieu");
+
+                // Can also access the property by accessor, like it was a dictionary.
+                name = obj["name"];
+                name.Should().Be("Mathieu");
+
+                rowCount += 1;
+            }
+
+            rowCount.Should().Be(1);
+        }
+    }
+}

--- a/rethinkdb-net-test/rethinkdb-net-test.csproj
+++ b/rethinkdb-net-test/rethinkdb-net-test.csproj
@@ -124,6 +124,8 @@
     <Compile Include="Integration\TestObjectWithDictionary.cs" />
     <Compile Include="Integration\NamedValueDictionaryTests.cs" />
     <Compile Include="DatumConverters\NamedValueDictionaryConverterTests.cs" />
+    <Compile Include="Integration\DynamicTestObject.cs" />
+    <Compile Include="Integration\DynamicTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/rethinkdb-net/Connection.cs
+++ b/rethinkdb-net/Connection.cs
@@ -44,7 +44,8 @@ namespace RethinkDb
                     TimeSpanDatumConverterFactory.Instance,
                     GroupingDictionaryDatumConverterFactory.Instance,
                     ObjectDatumConverterFactory.Instance,
-                    NamedValueDictionaryDatumConverterFactory.Instance
+                    NamedValueDictionaryDatumConverterFactory.Instance,
+                    RethinkDbObjectDatumConverterFactory.Instance
                 ),
                 new Expressions.DefaultExpressionConverterFactory()
             );

--- a/rethinkdb-net/DatumConverters/AbstractDatumConverterFactory.cs
+++ b/rethinkdb-net/DatumConverters/AbstractDatumConverterFactory.cs
@@ -100,7 +100,8 @@ namespace RethinkDb.DatumConverters
                             }
                         }
 
-                        return typeof(Dictionary<string, object>);
+                        return typeof(RethinkDbObject);
+                        //return typeof(Dictionary<string, object>);
                     }
                 
                 case Datum.DatumType.R_STR:

--- a/rethinkdb-net/DatumConverters/ObjectDatumConverterFactory.cs
+++ b/rethinkdb-net/DatumConverters/ObjectDatumConverterFactory.cs
@@ -48,9 +48,14 @@ namespace RethinkDb.DatumConverters
             if (obj == null)
                 return new Datum() { type = Datum.DatumType.R_NULL };
 
+            var valueConverter = rootDatumConverterFactory.Get(obj.GetType());
+            return valueConverter.ConvertObject(obj);
+
+            /*
             // What to do here... I don't know why someone would be doing this in the first place, we really only expected
             // to return null here.  Once we find the use-case that this works for, we'll worry about it.
             throw new Exception("Not able to convert non-null Object to a ReQL datum");
+            */
         }
 
         #endregion

--- a/rethinkdb-net/DatumConverters/RethinkDbObjectDatumConverterFactory.cs
+++ b/rethinkdb-net/DatumConverters/RethinkDbObjectDatumConverterFactory.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using RethinkDb.Spec;
+
+namespace RethinkDb.DatumConverters
+{
+    public class RethinkDbObjectDatumConverterFactory : AbstractDatumConverterFactory
+    {
+        public static readonly RethinkDbObjectDatumConverterFactory Instance = new RethinkDbObjectDatumConverterFactory();
+
+        private RethinkDbObjectDatumConverterFactory()
+        {
+        }
+
+        public override bool TryGet<T>(IDatumConverterFactory rootDatumConverterFactory, out IDatumConverter<T> datumConverter)
+        {
+            if (typeof(T) == typeof(RethinkDbObject))
+            {
+                datumConverter = (IDatumConverter<T>)new RethinkDbObjectDatumConverter(rootDatumConverterFactory);
+                return true;
+            }
+
+            datumConverter = null;
+            return false;
+        }
+
+        private class RethinkDbObjectDatumConverter : AbstractReferenceTypeDatumConverter<RethinkDbObject>
+        {
+            private IDatumConverter<Dictionary<string, object>> dictionaryDatumConverter;
+
+            public RethinkDbObjectDatumConverter(IDatumConverterFactory rootDatumConverterFactory)
+            {
+                this.dictionaryDatumConverter = rootDatumConverterFactory.Get<Dictionary<string, object>>();
+            }
+
+            public override RethinkDbObject ConvertDatum(Datum datum)
+            {
+                if (datum.type == Spec.Datum.DatumType.R_NULL)
+                    return null;
+                return new RethinkDbObject(dictionaryDatumConverter.ConvertDatum(datum));
+            }
+
+            public override Datum ConvertObject(RethinkDbObject value)
+            {
+                if (value == null)
+                    return new Spec.Datum() { type = Spec.Datum.DatumType.R_NULL };
+                return dictionaryDatumConverter.ConvertObject(value.InnerDictionary);
+            }
+        }
+    }
+}

--- a/rethinkdb-net/RethinkDbObject.cs
+++ b/rethinkdb-net/RethinkDbObject.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Dynamic;
+
+namespace RethinkDb
+{
+    public class RethinkDbObject : DynamicObject
+    {
+        private readonly Dictionary<string, object> innerDictionary;
+
+        public RethinkDbObject(Dictionary<string, object> data)
+        {
+            this.innerDictionary = data;
+        }
+
+        public Dictionary<string, object> InnerDictionary
+        {
+            get { return innerDictionary; }
+        }
+
+        public override bool TryGetMember(GetMemberBinder binder, out object result)
+        {
+            return innerDictionary.TryGetValue(binder.Name, out result);
+        }
+
+        public override bool TryGetIndex(GetIndexBinder binder, object[] indexes, out object result)
+        {
+            result = null;
+            if (indexes.Length != 1)
+                return false;
+            return innerDictionary.TryGetValue((string)indexes[0], out result);
+        }
+    }
+}

--- a/rethinkdb-net/rethinkdb-net.csproj
+++ b/rethinkdb-net/rethinkdb-net.csproj
@@ -235,6 +235,8 @@
     <Compile Include="Protocols\Version_0_4_ProtobufProtocol.cs" />
     <Compile Include="DatumConverters\NamedValueDictionaryDatumConverterFactory.cs.cs" />
     <Compile Include="Expressions\DictionaryExpressionConverters.cs" />
+    <Compile Include="RethinkDbObject.cs" />
+    <Compile Include="DatumConverters\RethinkDbObjectDatumConverterFactory.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
Experimental work-in-progress!

I'm not quite sure where this work will end up.  Here's what I've experimented with so far:

* Creating a table with an object type "dynamic", rather than a specific type.
  * This allows the insertion of object types only; other types, like an int, seem to just fail silently.
  * Insertion of object types ends up at ObjectDatumConverter.ConvertObject.  I've modified this method to use the object's Type and find an appropriate datum converter, and then use that to convert the object to a datum.
* Reading values back from that table.
  * From the library's point of view, this ends up at ObjectDatumConverter.ConvertDatum.
  * Initially this would return a ```Dictionary&lt;string,object&gt;```.  But, if you inserted an object with fields, and got back a dictionary, your code would look weird... so I changed this to return a ```System.Dynamic.DynamicObject``` subclass that allows accessing the object data as both fields and index accessors.

I think fundamentally this is going to run into problems where the returned objects don't come back as the correct .NET types, and there's no avoiding that.  For example...

```
[DataContract]
public class Thing
{
    [DataMember(Name="id")]
    public string Id;
    [DataMember(Name="full_name")]
    public string FullName;
}

var testTable = Query.Db("test").Table<dynamic>("table");
connection.Run(testTable.Insert(new Thing() { Id = "id1", FullName = "Mathieu Fenniak" }));
var readThing = connection.Run(testTable).First();
```

In this code sample, what type does "readThing" have?  All the driver knows is: (a) the library user is asking for a ```System.Object``` type (that's what ```dynamic``` gets converted to when compiled), and (b) the data is an object with the fields "id" and "full_name".

```readThing``` could be a ```Dictionary&lt;string,object&gt;```, but, then I can't access readThing.Id.  It could be a RethinkDbObject (the type I just created in this prototype), and then I can access ```readThing.id``` or ```readThing.full_name```, but not ```readThing.id``` or ```readThing.FullName```.

Ultimately the best thing to return would be a ```Thing``` type, but the driver has no way to identify that as the correct type.

Anyway, aside from that, here are other problems that dynamic support will have:
* Not sure how we'll map special operators (like using + to concatate strings)
* Not sure how field, property, method accessors will work for dynamic types.
* Especially not sure how special behaviours currently built into rethinkdb-net would work; like accessing ```.Hour``` on a DateTime type.  If it's a dynamic, we'd never know it could be a DateTime and that we'd need to create a special term to access the hour from it.

Upon further investigation, it looks like ```dynamic``` operations cannot exist inside an expression tree.  This code snippet fails to compile:

```
var testTable = Query.Db("test").Table<dynamic>("table");
connection.Run(testTable.Insert(new { date = DateTime.UtcNow }));
var retval = connection.Run(testTable.Select(d => d.date.Year));
```

Because it would be impossible for the compiler to know what type of expression to create for ".date" and ".Year") inside the Select, the C# compiler prevents the usage of dynamic elements inside an expression tree.  This is basically a torpedo in the entire idea of using dynamic within rethinkdb-net; if we can't access anything in an expression tree, we'd be severely limited in what we could do.