### PR TITLE
Fix for ConvertAppendToTerm when dealing with scalar values

### DIFF
--- a/rethinkdb-net/Expressions/LinqExpressionConverters.cs
+++ b/rethinkdb-net/Expressions/LinqExpressionConverters.cs
@@ -127,14 +127,7 @@ namespace RethinkDb.Expressions
                     type = Term.TermType.APPEND
                 };
                 newTerm.args.Add(term);
-
-                if (datumExpression.NodeType == ExpressionType.MemberInit)
-                {
-                    var memberInit = (MemberInitExpression)datumExpression;
-                    newTerm.args.Add(recursiveMap(memberInit));
-                }
-                else
-                    throw new NotSupportedException(String.Format("Expected ReQLExpression.Append to contain MemberInit additions, but was: {0}", datumExpression.NodeType));
+                newTerm.args.Add(recursiveMap(datumExpression));
 
                 term = newTerm;
             }


### PR DESCRIPTION
Greetings again!

I had some problems with the `Append` function for arrays, because it expected each element to be a MemberInit expression. This made it impossible to write statements like:

```c#
someDocument.SomeNumbers.Append(1, 2, 3, 4)
```

Turns out, simply removing the check solves that problem.

Kind regards,
Nico