### PR TITLE
Implemented Compound Indexes

### DIFF
--- a/rethinkdb-net/CompoundIndex.cs
+++ b/rethinkdb-net/CompoundIndex.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Net;
+
+namespace RethinkDb
+{
+    public class CompoundIndex<TRecord>
+    {
+        private CompoundIndex() { }
+
+        internal Expression<Func<TRecord, object[]>> IndexExpression;
+
+        public static CompoundIndex<TRecord> Make<T1, T2>(Expression<Func<TRecord, T1>> indexExpression1,
+                                                                   Expression<Func<TRecord, T2>> indexExpression2)
+        {
+            return MakeRaw(indexExpression1.Body, indexExpression2.Body);
+        }
+
+        public static CompoundIndex<TRecord> Make<T1, T2, T3>(Expression<Func<TRecord, T1>> indexExpression1,
+                                                                       Expression<Func<TRecord, T2>> indexExpression2,
+                                                                       Expression<Func<TRecord, T3>> indexExpression3)
+        {
+            return MakeRaw(indexExpression1.Body, indexExpression2.Body, indexExpression3.Body);
+        }
+
+        public static CompoundIndex<TRecord> Make<T1, T2, T3, T4>(
+            Expression<Func<TRecord, T1>> indexExpression1,
+            Expression<Func<TRecord, T2>> indexExpression2,
+            Expression<Func<TRecord, T3>> indexExpression3,
+            Expression<Func<TRecord, T4>> indexExpression4)
+        {
+            return MakeRaw(indexExpression1.Body, indexExpression2.Body, indexExpression3.Body, indexExpression4.Body);
+        }
+
+        public static CompoundIndex<TRecord> Make<T1, T2, T3, T4, T5>(
+            Expression<Func<TRecord, T1>> indexExpression1,
+            Expression<Func<TRecord, T2>> indexExpression2,
+            Expression<Func<TRecord, T3>> indexExpression3,
+            Expression<Func<TRecord, T4>> indexExpression4,
+            Expression<Func<TRecord, T5>> indexExpression5)
+        {
+            return MakeRaw(indexExpression1.Body,
+                           indexExpression2.Body,
+                           indexExpression3.Body,
+                           indexExpression4.Body,
+                           indexExpression5.Body);
+        }
+
+        public static CompoundIndex<TRecord> Make<T1, T2, T3, T4, T5, T6>(
+            Expression<Func<TRecord, T1>> indexExpression1,
+            Expression<Func<TRecord, T2>> indexExpression2,
+            Expression<Func<TRecord, T3>> indexExpression3,
+            Expression<Func<TRecord, T4>> indexExpression4,
+            Expression<Func<TRecord, T5>> indexExpression5,
+            Expression<Func<TRecord, T6>> indexExpression6)
+        {
+            return MakeRaw(indexExpression1.Body,
+                           indexExpression2.Body,
+                           indexExpression3.Body,
+                           indexExpression4.Body,
+                           indexExpression5.Body,
+                           indexExpression6.Body);
+        }
+
+        public static CompoundIndex<TRecord> Make<T1, T2, T3, T4, T5, T6, T7>(
+            Expression<Func<TRecord, T1>> indexExpression1,
+            Expression<Func<TRecord, T2>> indexExpression2,
+            Expression<Func<TRecord, T3>> indexExpression3,
+            Expression<Func<TRecord, T4>> indexExpression4,
+            Expression<Func<TRecord, T5>> indexExpression5,
+            Expression<Func<TRecord, T6>> indexExpression6,
+            Expression<Func<TRecord, T7>> indexExpression7)
+        {
+            return MakeRaw(indexExpression1.Body,
+                           indexExpression2.Body,
+                           indexExpression3.Body,
+                           indexExpression4.Body,
+                           indexExpression5.Body,
+                           indexExpression6.Body,
+                           indexExpression7.Body);
+        }
+
+        public static CompoundIndex<TRecord> Make<T1, T2, T3, T4, T5, T6, T7, T8>(
+            Expression<Func<TRecord, T1>> indexExpression1,
+            Expression<Func<TRecord, T2>> indexExpression2,
+            Expression<Func<TRecord, T3>> indexExpression3,
+            Expression<Func<TRecord, T4>> indexExpression4,
+            Expression<Func<TRecord, T5>> indexExpression5,
+            Expression<Func<TRecord, T6>> indexExpression6,
+            Expression<Func<TRecord, T7>> indexExpression7,
+            Expression<Func<TRecord, T8>> indexExpression8)
+        {
+            return MakeRaw(indexExpression1.Body,
+                           indexExpression2.Body,
+                           indexExpression3.Body,
+                           indexExpression4.Body,
+                           indexExpression5.Body,
+                           indexExpression6.Body,
+                           indexExpression7.Body,
+                           indexExpression8.Body);
+        }
+
+        public static CompoundIndex<TRecord> Make<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+            Expression<Func<TRecord, T1>> indexExpression1,
+            Expression<Func<TRecord, T2>> indexExpression2,
+            Expression<Func<TRecord, T3>> indexExpression3,
+            Expression<Func<TRecord, T4>> indexExpression4,
+            Expression<Func<TRecord, T5>> indexExpression5,
+            Expression<Func<TRecord, T6>> indexExpression6,
+            Expression<Func<TRecord, T7>> indexExpression7,
+            Expression<Func<TRecord, T8>> indexExpression8,
+            Expression<Func<TRecord, T9>> indexExpression9)
+        {
+            return MakeRaw(indexExpression1.Body,
+                           indexExpression2.Body,
+                           indexExpression3.Body,
+                           indexExpression4.Body,
+                           indexExpression5.Body,
+                           indexExpression6.Body,
+                           indexExpression7.Body,
+                           indexExpression8.Body,
+                           indexExpression9.Body);
+        }
+
+        private static CompoundIndex<TRecord> MakeRaw(params Expression[] indexExpressions)
+        {
+            var param = Expression.Parameter(typeof(TRecord));
+            var visitor = new ParameterReplacingVisitor(param);
+
+            return new CompoundIndex<TRecord>
+            {
+                IndexExpression = Expression.Lambda<Func<TRecord, object[]>>(Expression.NewArrayInit(typeof(object),
+                                                                                                     indexExpressions.Select(expr => Expression.Convert(visitor.Visit(expr), typeof(object)))),
+                                                                             param)
+            };
+        }
+    }
+
+    internal class ParameterReplacingVisitor : ExpressionVisitor
+    {
+        private readonly ParameterExpression _parameter;
+
+        public ParameterReplacingVisitor(ParameterExpression parameter)
+        {
+            _parameter = parameter;
+        }
+
+        protected override Expression VisitParameter(ParameterExpression node)
+        {
+            return _parameter;
+        }
+    }
+}

--- a/rethinkdb-net/CompoundIndexKeys.cs
+++ b/rethinkdb-net/CompoundIndexKeys.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RethinkDb
+{
+    public class CompoundIndexKeys
+    {
+        private CompoundIndexKeys() { }
+
+        internal object[] Values { get; set; }
+
+        public static CompoundIndexKeys Make<T1, T2>(T1 value1, T2 value2)
+        {
+            return new CompoundIndexKeys { Values = new object[] { value1, value2 } };
+        }
+
+        public static CompoundIndexKeys Make<T1, T2, T3>(T1 value1, T2 value2, T3 value3)
+        {
+            return new CompoundIndexKeys { Values = new object[] { value1, value2, value3 } };
+        }
+
+        public static CompoundIndexKeys Make<T1, T2, T3, T4>(T1 value1, T2 value2, T3 value3, T4 value4)
+        {
+            return new CompoundIndexKeys { Values = new object[] { value1, value2, value3, value4 } };
+        }
+
+        public static CompoundIndexKeys Make<T1, T2, T3, T4, T5>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5)
+        {
+            return new CompoundIndexKeys { Values = new object[] { value1, value2, value3, value4, value5 } };
+        }
+
+        public static CompoundIndexKeys Make<T1, T2, T3, T4, T5, T6>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6)
+        {
+            return new CompoundIndexKeys { Values = new object[] { value1, value2, value3, value4, value5, value6 } };
+        }
+
+        public static CompoundIndexKeys Make<T1, T2, T3, T4, T5, T6, T7>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7)
+        {
+            return new CompoundIndexKeys { Values = new object[] { value1, value2, value3, value4, value5, value6, value7 } };
+        }
+
+        public static CompoundIndexKeys Make<T1, T2, T3, T4, T5, T6, T7, T8>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8)
+        {
+            return new CompoundIndexKeys { Values = new object[] { value1, value2, value3, value4, value5, value6, value7, value8 } };
+        }
+
+        public static CompoundIndexKeys Make<T1, T2, T3, T4, T5, T6, T7, T8, T9>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9)
+        {
+            return new CompoundIndexKeys { Values = new object[] { value1, value2, value3, value4, value5, value6, value7, value8, value9 } };
+        }
+    }
+}

--- a/rethinkdb-net/Connection.cs
+++ b/rethinkdb-net/Connection.cs
@@ -44,7 +44,8 @@ namespace RethinkDb
                     TimeSpanDatumConverterFactory.Instance,
                     GroupingDictionaryDatumConverterFactory.Instance,
                     ObjectDatumConverterFactory.Instance,
-                    NamedValueDictionaryDatumConverterFactory.Instance
+                    NamedValueDictionaryDatumConverterFactory.Instance,
+                    CompoundIndexDatumConverterFactory.Instance
                 ),
                 new Expressions.DefaultExpressionConverterFactory()
             );

--- a/rethinkdb-net/DatumConverters/CompoundIndexDatumConverterFactory.cs
+++ b/rethinkdb-net/DatumConverters/CompoundIndexDatumConverterFactory.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using RethinkDb.Spec;
+
+namespace RethinkDb.DatumConverters
+{
+    public class CompoundIndexDatumConverterFactory : AbstractDatumConverterFactory
+    {
+        public static readonly CompoundIndexDatumConverterFactory Instance = new CompoundIndexDatumConverterFactory();
+
+        public override bool TryGet<T>(IDatumConverterFactory rootDatumConverterFactory, out IDatumConverter<T> datumConverter)
+        {
+            if (rootDatumConverterFactory == null)
+                throw new ArgumentNullException("rootDatumConverterFactory");
+
+            datumConverter = null;
+
+            if (typeof(T) == typeof(CompoundIndexKeys))
+                datumConverter = (IDatumConverter<T>)new CompoundIndexDatumConverter(rootDatumConverterFactory);
+
+            return datumConverter != null;
+        }
+
+        public class CompoundIndexDatumConverter : AbstractReferenceTypeDatumConverter<CompoundIndexKeys>
+        {
+            private readonly IDatumConverterFactory _rootDatumConverterFactory;
+
+            public CompoundIndexDatumConverter(IDatumConverterFactory rootDatumConverterFactory)
+            {
+                _rootDatumConverterFactory = rootDatumConverterFactory;
+            }
+
+            public override CompoundIndexKeys ConvertDatum(Datum datum)
+            {
+                throw new NotSupportedException("Converting back to a CompoundIndexKeys object is not supported.");
+            }
+
+            public override Datum ConvertObject(CompoundIndexKeys compoundIndexKeys)
+            {
+                if (compoundIndexKeys == null)
+                    return new Datum {type = Datum.DatumType.R_NULL};
+
+                var retval = new Datum {type = Datum.DatumType.R_ARRAY};
+                foreach (var key in compoundIndexKeys.Values)
+                {
+                    var converter = _rootDatumConverterFactory.Get(key.GetType());
+                    retval.r_array.Add(converter.ConvertObject(key));
+                }
+
+                return retval;
+            }
+        }
+    }
+}

--- a/rethinkdb-net/Expressions/BaseExpression.cs
+++ b/rethinkdb-net/Expressions/BaseExpression.cs
@@ -147,6 +147,17 @@ namespace RethinkDb.Expressions
                     return AttemptClientSideConversion(datumConverterFactory, expr);
                 }
 
+                case ExpressionType.NewArrayInit:
+                    var arrayExpression = (NewArrayExpression)expr;
+                    var array = new Term {type = Term.TermType.MAKE_ARRAY};
+
+                    foreach (var expression in arrayExpression.Expressions)
+                    {
+                        array.args.Add(RecursiveMap(expression));
+                    }
+
+                    return array;
+
                 case ExpressionType.Call:
                 {
                     var callExpression = (MethodCallExpression)expr;

--- a/rethinkdb-net/Query.cs
+++ b/rethinkdb-net/Query.cs
@@ -60,6 +60,11 @@ namespace RethinkDb
             return new IndexCreateQuery<T, TIndexExpression>(target, indexName, indexExpression, multiIndex);
         }
 
+        public static CompoundIndexCreateQuery<T> IndexCreate<T>(this ITableQuery<T> target, string indexName, CompoundIndex<T> compoundIndex)
+        {
+            return new CompoundIndexCreateQuery<T>(target, indexName, compoundIndex.IndexExpression);
+        } 
+
         public static IndexWaitQuery<T> IndexWait<T>(this ITableQuery<T> target, params string[] indexNames)
         {
             return new IndexWaitQuery<T>(target, indexNames);

--- a/rethinkdb-net/QueryTerm/CompoundIndexCreateQuery.cs
+++ b/rethinkdb-net/QueryTerm/CompoundIndexCreateQuery.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RethinkDb.QueryTerm
+{
+    public class CompoundIndexCreateQuery<TTable> : IndexCreateQuery<TTable, object[]>
+    {
+        public CompoundIndexCreateQuery(ITableQuery<TTable> tableTerm, string indexName, Expression<Func<TTable, object[]>> indexExpression) 
+            : base(tableTerm, indexName, indexExpression, false)
+        {
+        }
+    }
+}

--- a/rethinkdb-net/rethinkdb-net.csproj
+++ b/rethinkdb-net/rethinkdb-net.csproj
@@ -50,10 +50,14 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CompoundIndex.cs" />
+    <Compile Include="CompoundIndexKeys.cs" />
     <Compile Include="Conflict.cs" />
     <Compile Include="Connection.cs" />
+    <Compile Include="DatumConverters\CompoundIndexDatumConverterFactory.cs" />
     <Compile Include="DatumConverters\EnumDatumConverterFactory.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="QueryTerm\CompoundIndexCreateQuery.cs" />
     <Compile Include="QueryTerm\HasFieldsQuery.cs" />
     <Compile Include="QueryTerm\TableListQuery.cs" />
     <Compile Include="QueryTerm\DbCreateQuery.cs" />


### PR DESCRIPTION
Greetings!

I wanted to use compound indexes with the driver, but that feature was not implemented. Turns out it works by providing an array as an index:

```c#
Person.Db.GetAll<Person, string[]>(new[] { "a", "b", "c" }, "AbcIndex");
```

This is kind of awkward and makes it impossible to use compound indexes with varying types (`object[]` does not work). Furthermore, there was no way to programmatically create a compound index.

I extended the driver with a way to define those compound indexes. Here is how you can use it with GetAll:

```c#
Person.Db.GetAll<Person, CompoundIndexKeys>(CompoundIndexKeys.Make("a", "b", 10, true, 2.5), "AbcIndex");
```

And here is how you can create new compound indexes:

```c#
Person.Db.IndexCreate("AbcIndex", CompoundIndex<Person>.Make(a => a.SomeString, a => a.SomeOtherString, a => a.SomeNumber, a => a.SomeBool, a => a.SomeFloatingPoint));
```

Kind regards,
Nico