### PR TITLE
Allow MemberInit inside of a conditional expression

### DIFF
--- a/rethinkdb-net/Expressions/BaseExpression.cs
+++ b/rethinkdb-net/Expressions/BaseExpression.cs
@@ -42,7 +42,7 @@ namespace RethinkDb.Expressions
         #endregion
         #region Parameter-independent Mappings
 
-        protected abstract Term RecursiveMap(Expression expression);
+        protected abstract Term RecursiveMap(Expression expression, bool allowMemberInit = false);
 
         private Term ConvertBinaryExpressionToTerm(BinaryExpression expr, IDatumConverterFactory datumConverterFactory)
         {
@@ -183,8 +183,8 @@ namespace RethinkDb.Expressions
                         type = Term.TermType.BRANCH,
                         args = {
                             RecursiveMap(conditionalExpression.Test),
-                            RecursiveMap(conditionalExpression.IfTrue),
-                            RecursiveMap(conditionalExpression.IfFalse)
+                            RecursiveMap(conditionalExpression.IfTrue, true),
+                            RecursiveMap(conditionalExpression.IfFalse, true)
                         }
                     };
                 }

--- a/rethinkdb-net/Expressions/DefaultExpressionConverterFactory.cs
+++ b/rethinkdb-net/Expressions/DefaultExpressionConverterFactory.cs
@@ -9,7 +9,7 @@ namespace RethinkDb.Expressions
 {
     public class DefaultExpressionConverterFactory : IExpressionConverterFactory
     {
-        public delegate Term RecursiveMapDelegate(Expression expression);
+        public delegate Term RecursiveMapDelegate(Expression expression, bool allowMemberInit = false);
         public delegate Term ExpressionMappingDelegate<T>(
             T expression,
             RecursiveMapDelegate recursiveMap,

--- a/rethinkdb-net/Expressions/SingleParameterLambda.cs
+++ b/rethinkdb-net/Expressions/SingleParameterLambda.cs
@@ -92,8 +92,11 @@ namespace RethinkDb.Expressions
             return retval;
         }
 
-        protected override Term RecursiveMap(Expression expression)
+        protected override Term RecursiveMap(Expression expression, bool allowMemberInit = false)
         {
+            if (allowMemberInit && expression.NodeType == ExpressionType.MemberInit)
+                return MapMemberInitToTerm((MemberInitExpression)expression);
+
             return MapExpressionToTerm(expression);
         }
 

--- a/rethinkdb-net/Expressions/TwoParameterLambda.cs
+++ b/rethinkdb-net/Expressions/TwoParameterLambda.cs
@@ -165,8 +165,11 @@ namespace RethinkDb.Expressions
             }
         }
 
-        protected override Term RecursiveMap(Expression expression)
+        protected override Term RecursiveMap(Expression expression, bool allowMemberInit = false)
         {
+            if (allowMemberInit && expression.NodeType == ExpressionType.MemberInit)
+                return MapMemberInitToTerm((MemberInitExpression)expression);
+
             return MapExpressionToTerm(expression);
         }
 

--- a/rethinkdb-net/Expressions/ZeroParameterLambda.cs
+++ b/rethinkdb-net/Expressions/ZeroParameterLambda.cs
@@ -24,7 +24,7 @@ namespace RethinkDb.Expressions
         #endregion
         #region Abstract implementation
 
-        protected override Term RecursiveMap(Expression expression)
+        protected override Term RecursiveMap(Expression expression, bool allowMemberInit = false)
         {
             return SimpleMap(datumConverterFactory, expression);
         }


### PR DESCRIPTION
It's me again,

this is the last one for now. This one makes it possible to use MemberInit expressions inside of conditional expressions, allowing you to do things like:

```c#
query.Update(t => (t.SomeCondition ? new Person { ... } : t))
```

This is quite handy if you want to update a document only if a condition evaluates to true, I guess it can be handy in other cases as well.

Sorry for the sudden burst of pull requests, I made these changes for a project which is now going to prod and I wanted to make sure everything works before I submit them to you. Thanks for the driver by the way!

Kind regards,
Nico