### PR TITLE
Fix for ConvertAppendToTerm when dealing with scalar values

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,7 +2,12 @@
 
 ## Next Release
 
+### Features
+
 * Added working Reset function to all query enumerators to reissue the query from the beginning.  [Issues #148](https://github.com/mfenniak/rethinkdb-net/issues/148)
+
+* Remove restriction on the array Append operation that prevented adding scalar values to arrays; thanks to @nkreipke for the patch.  [PR #227](https://github.com/mfenniak/rethinkdb-net/pull/227) / [PR #232](https://github.com/mfenniak/rethinkdb-net/pull/232)
+
 
 ## 0.11.0.0 (2015-04-18)
 

--- a/rethinkdb-net-test/Integration/SingleObjectTests.cs
+++ b/rethinkdb-net-test/Integration/SingleObjectTests.cs
@@ -278,5 +278,11 @@ namespace RethinkDb.Test.Integration
             var slice = connection.Run(testTable.Map(testObject => testObject.Data.Slice(0, 2, Bound.Open, Bound.Closed))).Single();
             Assert.That(slice, Is.EquivalentTo(new byte[] { 2, 3 }));
         }
+
+        [Test]
+        public void AppendScalarValue()
+        {
+            connection.Run(testTable.Update(o => new TestObject() { Tags = o.Tags.Append("mango") }));
+        }
     }
 }

--- a/rethinkdb-net/Expressions/LinqExpressionConverters.cs
+++ b/rethinkdb-net/Expressions/LinqExpressionConverters.cs
@@ -127,14 +127,7 @@ namespace RethinkDb.Expressions
                     type = Term.TermType.APPEND
                 };
                 newTerm.args.Add(term);
-
-                if (datumExpression.NodeType == ExpressionType.MemberInit)
-                {
-                    var memberInit = (MemberInitExpression)datumExpression;
-                    newTerm.args.Add(recursiveMap(memberInit));
-                }
-                else
-                    throw new NotSupportedException(String.Format("Expected ReQLExpression.Append to contain MemberInit additions, but was: {0}", datumExpression.NodeType));
+                newTerm.args.Add(recursiveMap(datumExpression));
 
                 term = newTerm;
             }


### PR DESCRIPTION
Updated @nkreipke's PR #227 to include an integration test.