### PR TITLE
Allow client-side access to unsupported fields

### DIFF
--- a/rethinkdb-net-test/Integration/SingleObjectTests.cs
+++ b/rethinkdb-net-test/Integration/SingleObjectTests.cs
@@ -5,6 +5,7 @@ using System.Linq.Expressions;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using RethinkDb;
+using System.Runtime.Serialization;
 
 namespace RethinkDb.Test.Integration
 {
@@ -305,6 +306,19 @@ namespace RethinkDb.Test.Integration
         {
             string[] values = new[] { "mango", "peach", "diet" };
             connection.Run(testTable.Update(o => new TestObject() { Tags = o.Tags.Append(values) }));
+        }
+
+        [DataContract]
+        public class DataContractWithoutDataMembers
+        {
+            public double[] SomeNumberArray;
+        }
+
+        [Test]
+        public void AccessingMemberOnDataContract()
+        {
+            var localObject = new DataContractWithoutDataMembers { SomeNumberArray = new[] { 1d, 2d, 3d } };
+            connection.Run(testTable.Filter(o => localObject.SomeNumberArray.Contains(o.SomeNumber))).ToArray();
         }
     }
 }

--- a/rethinkdb-net/Expressions/BaseExpression.cs
+++ b/rethinkdb-net/Expressions/BaseExpression.cs
@@ -239,8 +239,12 @@ namespace RethinkDb.Expressions
 
             var datumFieldName = fieldConverter.GetDatumFieldName(memberExpression.Member);
             if (string.IsNullOrEmpty(datumFieldName))
+            {
                 // At this point we're not returning false because we're expecting this should work; throwing an error instead.
-                throw new NotSupportedException(String.Format("Member {0} on type {1} could not be mapped to a datum field", memberExpression.Member.Name, memberExpression.Type));
+                // We're expecting this to work, but, returning false will give us a chance to try client-side evaluation instead and
+                // maintain compatibility with the pre-PR #209 behaviour. (issue #220).
+                return false;
+            }
 
             var getAttrTerm = new Term()
             {


### PR DESCRIPTION
If a field is on a type that can be accessed server-side, but the field can't be, access it client-side.  Will fix #220.